### PR TITLE
Release/v0.4.0

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,16 @@
+return {
+  _all = {
+    -- Path to search for Lua modules
+    lpath = "./lua/?.lua;./lua/?/init.lua",
+    -- Initial file to load before running tests
+    helper = "tests/minimal_init.lua",
+    -- Don't generate coverage reports (can be enabled if needed)
+    coverage = false,
+  },
+  default = {
+    -- Run tests in 'tests' directory by default
+    ROOT = { "tests/checkmate" },
+    pattern = "_spec.lua$",
+    verbose = true,
+  },
+}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - README.md
       - .github/workflows/panvimdoc.yml
+  pull_request:
+    branches:
+      - main # Run on PRs targeting main
+    paths:
+      - README.md
+      - .github/workflows/panvimdoc.yml
+  workflow_dispatch: # Allow manual triggering
 
 permissions:
   contents: write

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,13 @@
 ---
-on: [push, pull_request]
 name: lint-test
+on:
+  push:
+    branches:
+      - main # Only run on push to main
+  pull_request:
+    branches:
+      - main # Run on PRs targeting main
+  workflow_dispatch: # Allow manual triggering
 
 jobs:
   stylua:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,7 +16,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    if: false
     strategy:
       matrix:
         nvim-versions: ["stable", "nightly"]
@@ -24,11 +23,19 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-
-      - uses: rhysd/action-setup-vim@v1
+        with:
+          fetch-depth: 0
+      - name: setup neovim
+        uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: ${{ matrix.nvim-versions }}
-
+      # Install Lua and LuaRocks - for busted and other dependencies
+      - name: Setup Lua
+        uses: leafo/gh-actions-lua@v11
+        with:
+          luaVersion: "5.1" # match Neovim's Lua version
+      - name: Setup LuaRocks
+        uses: leafo/gh-actions-luarocks@v5
       - name: run tests
         run: make test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches:
       - main
+      - "release/**"
 
 permissions:
   contents: write
-  packages: write
   pull-requests: write
 
 jobs:
@@ -18,9 +18,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: googleapis/release-please-action@v4
+      - name: Release Please
+        uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.PAT }}
           config-file: release-please-config.json
+          # Tell it to open/update the PR against whichever branch triggered this run:
+          target-branch: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logs/
 Dockerfile
 
 .DS_Store
+
+.testdata

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:
 # Run a specific test file
 # Usage: make test-file FILE=tests/specs/parser_spec.lua
 test-file:
-	nvim -l tests/busted.lua $(FILE) tests/custom_reporter --color
+	nvim -l tests/busted.lua $(FILE) tests/custom_reporter -Xoutput color
 
 # Enter test environment for interactive testing
 test-interactive:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
-TESTS_INIT=tests/minimal_init.lua
-TESTS_DIR=tests/
+.PHONY: test test-file test-interactive clean
 
-.PHONY: test
-
+# Run all tests
 test:
-	@nvim \
-		--headless \
-		--noplugin \
-		-u ${TESTS_INIT} \
-		-c "PlenaryBustedDirectory ${TESTS_DIR} { minimal_init = '${TESTS_INIT}' }"
+	nvim -l tests/busted.lua tests/checkmate -o tests/custom_reporter -Xoutput color
+
+# Run a specific test file
+# Usage: make test-file FILE=tests/specs/parser_spec.lua
+test-file:
+	nvim -l tests/busted.lua $(FILE) tests/custom_reporter --color
+
+# Enter test environment for interactive testing
+test-interactive:
+	nvim -u tests/busted.lua
+
+# Clean test data
+clean:
+	rm -rf .testdata

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -296,6 +296,7 @@ function M.handle_toggle(bufnr, line_row, col, opts)
   elseif target_state == todo_item.state then
     -- Already in target state, no change needed
     log.debug("Todo item already in target state: " .. target_state, { module = "api" })
+    util.notify("Todo item is already " .. target_state, log.levels.INFO)
     return nil, todo_item
   end
 
@@ -365,10 +366,10 @@ function M.create_todo()
   local row = cursor[1] - 1 -- 0-indexed
   local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
 
-  local todo_markers = config.options.todo_markers
-  -- Check if line already has a task marker
-  if line:match(todo_markers.unchecked) or line:match(todo_markers.checked) then
+  local todo_state = parser.get_todo_item_state(line)
+  if todo_state ~= nil then
     log.debug("Line already has a todo marker, skipping", { module = "api" })
+    util.notify(("Todo item already exists on row %d!"):format(row + 1), log.levels.INFO)
     return
   end
 

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -144,16 +144,22 @@ function M.setup_autocmds(bufnr)
   local augroup = vim.api.nvim_create_augroup(augroup_name, { clear = true })
 
   if not vim.b[bufnr].checkmate_autocmds_setup then
+    -- This implementation addresses several subtle behavior issues:
+    --   1. vim.schedule() is used to defer setting the modified=false until after
+    -- the autocmd completes. Otherwise, Neovim wasn't calling BufWritCmd on subsequent rewrites.
+    --   2. Atomic write operation - ensures data integrity (either complete write success or
+    -- complete failure, with preservation of the original buffer) by using temp file with a
+    -- rename operation (which is atomic at the POSIX filesystem level)
+    --   3. A temp buffer is used to perform the unicode to markdown conversion in order to
+    -- keep a consistent visual experience for the user, maintain a clean undo history, and
+    -- maintain a clean separation between the display format (unicode) and storage format (Markdown)
     vim.api.nvim_create_autocmd("BufWriteCmd", {
       group = augroup,
       buffer = bufnr,
       desc = "Checkmate: Convert and save .todo files",
       callback = function()
-        log.debug("BufWriteCmd triggered for buffer " .. bufnr, { module = "api" })
-
-        -- This prevents Vim from thinking the write is unnecessary
+        local uv = vim.uv
         local was_modified = vim.bo[bufnr].modified
-        vim.bo[bufnr].modified = true
 
         -- Get the current lines and filename
         local current_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
@@ -162,28 +168,60 @@ function M.setup_autocmds(bufnr)
         -- Create temp buffer and convert to markdown
         local temp_bufnr = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_lines(temp_bufnr, 0, -1, false, current_lines)
-        parser.convert_unicode_to_markdown(temp_bufnr)
+
+        -- Convert Unicode to markdown
+        local success = parser.convert_unicode_to_markdown(temp_bufnr)
+        if not success then
+          log.error("Failed to convert Unicode to Markdown", { module = "api" })
+          vim.api.nvim_buf_delete(temp_bufnr, { force = true })
+          util.notify("Failed to save: conversion error", vim.log.levels.ERROR)
+          return false
+        end
 
         -- Get converted lines and write to file
         local markdown_lines = vim.api.nvim_buf_get_lines(temp_bufnr, 0, -1, false)
 
-        local write_ok = (vim.fn.writefile(markdown_lines, filename, "b") == 0)
+        -- Create temporary file path
+        local temp_filename = filename .. ".tmp"
+
+        -- Write to temporary file first
+        local write_result = vim.fn.writefile(markdown_lines, temp_filename, "b")
 
         -- Clean up temp buffer
         vim.api.nvim_buf_delete(temp_bufnr, { force = true })
 
-        if write_ok then
-          -- CRITICAL: Set modified to what it was before
-          -- but let Vim handle this AFTER we return
+        if write_result == 0 then
+          -- Atomically rename the temp file to the target file
+          local ok, rename_err = pcall(function()
+            uv.fs_rename(temp_filename, filename)
+          end)
+
+          if not ok then
+            -- If rename fails, try to clean up and report error
+            pcall(function()
+              uv.fs_unlink(temp_filename)
+            end)
+            log.error("Failed to rename temp file: " .. (rename_err or "unknown error"), { module = "api" })
+            util.notify("Failed to save file", vim.log.levels.ERROR)
+            vim.bo[bufnr].modified = was_modified
+            return false
+          end
+
+          -- Use schedule to set modified flag after command completes
           vim.schedule(function()
             vim.bo[bufnr].modified = false
           end)
 
-          vim.notify("File saved", vim.log.levels.INFO)
+          util.notify("File saved", vim.log.levels.INFO)
         else
-          vim.notify("Failed to save file", vim.log.levels.ERROR)
+          -- Failed to write temp file
+          -- Try to clean up
+          pcall(function()
+            uv.fs_unlink(temp_filename)
+          end)
+          util.notify("Failed to write file", vim.log.levels.ERROR)
           vim.bo[bufnr].modified = was_modified
-          return false -- Only return early on failure
+          return false
         end
       end,
     })

--- a/lua/checkmate/log.lua
+++ b/lua/checkmate/log.lua
@@ -4,12 +4,12 @@ local M = {}
 
 -- Log levels
 M.levels = {
-  TRACE = 1,
-  DEBUG = 2,
-  INFO = 3,
-  WARN = 4,
-  ERROR = 5,
-  OFF = 6,
+  TRACE = 0,
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR = 4,
+  OFF = 5,
 }
 
 -- Maps string level names to numeric values

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -1,0 +1,20 @@
+#!/usr/bin/env -S nvim -l
+
+-- Set up test environment in an isolated location
+vim.env.LAZY_STDPATH = ".testdata"
+
+-- Bootstrap lazy.nvim
+load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
+
+-- Setup lazy.nvim with busted and all test dependencies
+require("lazy.minit").busted({
+  spec = {
+    { dir = vim.uv.cwd() },
+    -- Plugin dependencies for testing
+  },
+  headless = {
+    process = false,
+    log = false,
+    task = false,
+  },
+})

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -1,0 +1,435 @@
+describe("API", function()
+  lazy_setup(function()
+    -- Hide nvim_echo from polluting test output
+    stub(vim.api, "nvim_echo")
+  end)
+
+  lazy_teardown(function()
+    ---@diagnostic disable-next-line: undefined-field
+    vim.api.nvim_echo:revert()
+  end)
+
+  before_each(function()
+    _G.reset_state()
+  end)
+
+  -- Create a temporary file for testing
+  local function create_temp_file()
+    local temp_dir = vim.fn.tempname()
+    vim.fn.mkdir(temp_dir, "p")
+    local file_path = temp_dir .. "/test.todo"
+    return file_path
+  end
+
+  -- Read file contents directly (not via Neovim buffer)
+  local function read_file_content(file_path)
+    local f = io.open(file_path, "r")
+    if not f then
+      return nil
+    end
+    local content = f:read("*all")
+    f:close()
+    return content
+  end
+
+  -- Write content to file directly
+  local function write_file_content(file_path, content)
+    local f = io.open(file_path, "w")
+    if not f then
+      return false
+    end
+    f:write(content)
+    f:close()
+    return true
+  end
+
+  -- Set up a todo file in a buffer with autocmds
+  local function setup_todo_buffer(file_path, content)
+    write_file_content(file_path, content)
+
+    -- Open the file in a buffer
+    vim.cmd("edit " .. file_path)
+    local bufnr = vim.api.nvim_get_current_buf()
+
+    -- Ensure filetype is set to markdown
+    vim.bo[bufnr].filetype = "markdown"
+
+    -- Set up the API for this buffer
+    require("checkmate.api").setup(bufnr)
+
+    return bufnr
+  end
+
+  describe("file operations", function()
+    it("should save todo file with correct Markdown syntax", function()
+      local config = require("checkmate.config")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      -- Create a test todo file
+      local file_path = create_temp_file()
+
+      -- Initial content with Unicode symbols
+      local content = "# Todo List\n\n- " .. unchecked .. " Unchecked task\n- " .. checked .. " Checked task\n"
+
+      -- Setup buffer with the content
+      local bufnr = setup_todo_buffer(file_path, content)
+
+      -- Force a write operation - triggering our BufWriteCmd handler
+      vim.cmd("write")
+
+      -- Wait for the save operation to complete
+      vim.cmd("sleep 10m")
+
+      -- Read the saved file content directly (should be in Markdown format)
+      local saved_content = read_file_content(file_path)
+
+      -- Verify content was saved as Markdown
+      assert.not_nil(saved_content)
+      assert.matches("- %[%s%] Unchecked task", saved_content) -- "- [ ] Unchecked task"
+      assert.matches("- %[x%] Checked task", saved_content) -- "- [x] Checked task"
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+
+    it("should load todo file with Markdown checkboxes converted to Unicode", function()
+      -- Create a test todo file
+      local file_path = create_temp_file()
+
+      -- Initial content with Markdown format
+      local content = "# Todo List\n\n- [ ] Unchecked task\n- [x] Checked task\n"
+      write_file_content(file_path, content)
+
+      -- Open the file in Neovim
+      vim.cmd("edit " .. file_path)
+      local bufnr = vim.api.nvim_get_current_buf()
+
+      -- Ensure filetype is set to markdown
+      vim.bo[bufnr].filetype = "markdown"
+
+      -- Set up the API for this buffer - this should trigger conversion
+      require("checkmate.api").setup(bufnr)
+
+      -- Get the buffer content
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      local buffer_content = table.concat(lines, "\n")
+
+      -- Verify content was converted to Unicode
+      local config = require("checkmate.config")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      assert.matches("- " .. vim.pesc(unchecked) .. " Unchecked task", buffer_content)
+      assert.matches("- " .. vim.pesc(checked) .. " Checked task", buffer_content)
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+
+    it("should maintain todo state through edit-save-reload cycle", function()
+      local config = require("checkmate.config")
+      local api = require("checkmate.api")
+      local unchecked = config.options.todo_markers.unchecked
+
+      -- Create a test todo file
+      local file_path = create_temp_file()
+
+      -- Initial content with just unchecked items
+      local content = "# Todo List\n\n- [ ] Task 1\n- [ ] Task 2\n- [ ] Task 3\n"
+
+      -- Setup buffer with the content
+      local bufnr = setup_todo_buffer(file_path, content)
+
+      -- Get the task we want to toggle
+      local todo_map = require("checkmate.parser").discover_todos(bufnr)
+      local task_2 = nil
+
+      for _, todo in pairs(todo_map) do
+        if vim.startswith(todo.todo_text, "- " .. unchecked .. " Task 2") then
+          task_2 = todo
+          break
+        end
+      end
+
+      assert.is_not_nil(task_2)
+
+      -- Toggle task 2 to checked
+      local err, toggled = api.handle_toggle(bufnr, nil, nil, {
+        existing_todo_item = task_2,
+      })
+
+      assert.is_nil(err)
+      ---@diagnostic disable-next-line: need-check-nil
+      assert.equals("checked", toggled.state)
+
+      -- Save the file
+      vim.cmd("write")
+      vim.cmd("sleep 10m")
+
+      -- Close and reopen the file
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+      vim.cmd("edit " .. file_path)
+      bufnr = vim.api.nvim_get_current_buf()
+
+      -- Ensure filetype is set to markdown
+      vim.bo[bufnr].filetype = "markdown"
+
+      -- Set up the API for this buffer - this should trigger conversion
+      api.setup(bufnr)
+
+      -- Check that Task 2 is still checked
+      todo_map = require("checkmate.parser").discover_todos(bufnr)
+      ---@type checkmate.TodoItem
+      local task_2_reloaded = nil
+
+      for _, todo in pairs(todo_map) do
+        if vim.startswith(todo.todo_text, "- " .. config.options.todo_markers.checked .. " Task 2") then
+          task_2_reloaded = todo
+          break
+        end
+      end
+
+      assert.is_not_nil(task_2_reloaded)
+      assert.equals("checked", task_2_reloaded.state)
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+  end)
+
+  describe("todo creation and manipulation", function()
+    it("should create a new todo item", function()
+      -- Create a test todo file
+      local file_path = create_temp_file()
+
+      -- Initial content with no todos
+      local content = "# Todo List\n\nThis is a regular line\n"
+
+      -- Setup buffer with the content
+      local bufnr = setup_todo_buffer(file_path, content)
+
+      -- Move cursor to the regular line
+      vim.api.nvim_win_set_cursor(0, { 3, 0 })
+
+      -- Create a todo item
+      require("checkmate").create()
+
+      -- Get the buffer content
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+      -- Verify a todo was created on line 3
+      local config = require("checkmate.config")
+      local unchecked = config.options.todo_markers.unchecked
+      assert.matches("- " .. vim.pesc(unchecked) .. " This is a regular line", lines[3])
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+
+    it("should add metadata to todo items", function()
+      local config = require("checkmate.config")
+      local unchecked = config.options.todo_markers.unchecked
+
+      -- Create a test todo file
+      local file_path = create_temp_file()
+
+      -- Initial content with a todo
+      local content = "# Todo List\n\n- [ ] Task without metadata\n"
+
+      -- Setup buffer with the content
+      local bufnr = setup_todo_buffer(file_path, content)
+
+      -- Move cursor to the todo line
+      vim.api.nvim_win_set_cursor(0, { 3, 0 })
+
+      -- Find the todo item at cursor
+      local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 2, 0)
+      assert.is_not_nil(todo_item)
+
+      -- Add priority metadata
+      require("checkmate").add_metadata("priority", "high")
+
+      -- Get the buffer content
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+      -- Verify metadata was added
+      assert.matches("- " .. vim.pesc(unchecked) .. " Task without metadata @priority%(high%)", lines[3])
+
+      -- Save the file
+      vim.cmd("write")
+      vim.cmd("sleep 10m")
+
+      -- Read file directly
+      local saved_content = read_file_content(file_path)
+
+      -- Verify metadata was saved
+      assert.matches("- %[ %] Task without metadata @priority%(high%)", saved_content)
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+
+    it("should work with todo hierarchies", function()
+      local config = require("checkmate.config")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      -- Create a test todo file with nested todos
+      local file_path = create_temp_file()
+
+      -- Initial content with hierarchical todos
+      local content = [[
+# Todo Hierarchy
+
+- [ ] Parent task
+  - [ ] Child task 1
+  - [ ] Child task 2
+    - [ ] Grandchild task
+  - [ ] Child task 3
+- [ ] Another parent
+]]
+
+      -- Setup buffer with the content
+      local bufnr = setup_todo_buffer(file_path, content)
+
+      -- Get parent and child todos
+      local todo_map = require("checkmate.parser").discover_todos(bufnr)
+
+      -- Find parent todo
+      ---@type checkmate.TodoItem
+      local parent_todo = nil
+      for _, todo in pairs(todo_map) do
+        if vim.startswith(todo.todo_text, "- " .. unchecked .. " Parent task") then
+          parent_todo = todo
+          break
+        end
+      end
+
+      assert.is_not_nil(parent_todo)
+      assert.equals(3, #parent_todo.children, "Parent should have 3 children")
+
+      -- Toggle parent to checked
+      require("checkmate.api").handle_toggle(bufnr, nil, nil, {
+        existing_todo_item = parent_todo,
+        target_state = "checked",
+      })
+
+      -- Get updated content
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+      -- Verify parent is checked
+      assert.matches("- " .. vim.pesc(checked) .. " Parent task", lines[3], "Parent should be checked after toggle")
+
+      -- Save
+      vim.cmd("write")
+      vim.cmd("sleep 10m")
+
+      -- Read directly
+      local saved_content = read_file_content(file_path)
+
+      if not saved_content then
+        error("error reading file content")
+      end
+
+      -- Split the content into lines for precise line-by-line verification
+      local saved_lines = {}
+      for line in saved_content:gmatch("([^\n]*)\n?") do
+        table.insert(saved_lines, line)
+      end
+
+      -- Verify saved correctly with exact indentation
+      assert.equals("# Todo Hierarchy", saved_lines[1])
+      assert.equals("", saved_lines[2])
+      assert.equals("- [x] Parent task", saved_lines[3])
+      assert.equals("  - [ ] Child task 1", saved_lines[4], "Child task 1 should preserve 2-space indentation")
+      assert.equals("  - [ ] Child task 2", saved_lines[5], "Child task 2 should preserve 2-space indentation")
+      assert.equals("    - [ ] Grandchild task", saved_lines[6], "Grandchild task should preserve 4-space indentation")
+      assert.equals("  - [ ] Child task 3", saved_lines[7], "Child task 3 should preserve 2-space indentation")
+      assert.equals("- [ ] Another parent", saved_lines[8])
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+
+    it("should handle multiple todo operations in sequence", function()
+      local config = require("checkmate.config")
+
+      -- Create a test todo file
+      local file_path = create_temp_file()
+
+      -- Initial content with todos
+      local content = [[
+# Todo Sequence
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+]]
+
+      -- Setup buffer with the content
+      local bufnr = setup_todo_buffer(file_path, content)
+
+      -- Operations: toggle task 1, add metadata to task 2, check task 3
+
+      -- 1. Toggle task 1
+      vim.api.nvim_win_set_cursor(0, { 3, 3 }) -- Position on Task 1
+      require("checkmate").toggle()
+
+      -- 2. Add metadata to task 2
+      vim.api.nvim_win_set_cursor(0, { 4, 3 }) -- Position on Task 2
+      require("checkmate").add_metadata("priority", "high")
+
+      -- 3. Check task 3
+      vim.api.nvim_win_set_cursor(0, { 5, 3 }) -- Position on Task 3
+      require("checkmate").check()
+
+      -- Get updated content
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+      -- Verify all changes
+      local checked = config.options.todo_markers.checked
+      local unchecked = config.options.todo_markers.unchecked
+
+      assert.matches("- " .. vim.pesc(checked) .. " Task 1", lines[3])
+      assert.matches("- " .. vim.pesc(unchecked) .. " Task 2 @priority%(high%)", lines[4])
+      assert.matches("- " .. vim.pesc(checked) .. " Task 3", lines[5])
+
+      -- Save
+      vim.cmd("write")
+      vim.cmd("sleep 10m")
+
+      -- Read directly
+      local saved_content = read_file_content(file_path)
+
+      -- Verify saved correctly
+      assert.matches("- %[x%] Task 1", saved_content)
+      assert.matches("- %[ %] Task 2 @priority%(high%)", saved_content)
+      assert.matches("- %[x%] Task 3", saved_content)
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        os.remove(file_path)
+      end)
+    end)
+  end)
+end)

--- a/tests/checkmate/config_spec.lua
+++ b/tests/checkmate/config_spec.lua
@@ -1,0 +1,77 @@
+describe("Config", function()
+  local h = require("tests.checkmate.helpers")
+  lazy_setup(function()
+    -- Hide nvim_echo from polluting test output
+    stub(vim.api, "nvim_echo")
+  end)
+
+  lazy_teardown(function()
+    ---@diagnostic disable-next-line: undefined-field
+    vim.api.nvim_echo:revert()
+  end)
+
+  before_each(function()
+    _G.reset_state()
+
+    -- Back up any global state
+    _G.loaded_checkmate_bak = vim.g.loaded_checkmate
+    _G.checkmate_config_bak = vim.g.checkmate_config
+
+    -- Reset global state
+    vim.g.loaded_checkmate = nil
+    vim.g.checkmate_config = nil
+  end)
+
+  after_each(function()
+    -- Restore global state
+    vim.g.loaded_checkmate = _G.loaded_checkmate_bak
+    vim.g.checkmate_config = _G.checkmate_config_bak
+
+    -- Clean up any state
+    local config = require("checkmate.config")
+    if config.is_running() then
+      config.stop()
+    end
+  end)
+
+  describe("initializaiton", function()
+    it("should load with default options", function()
+      local config = require("checkmate.config")
+
+      assert.is_true(config.options.enabled)
+      assert.is_true(config.options.notify)
+      assert.equals("□", config.options.todo_markers.unchecked)
+      assert.equals("✔", config.options.todo_markers.checked)
+      assert.equals("-", config.options.default_list_marker)
+      assert.equals(1, config.options.todo_action_depth)
+      assert.is_true(config.options.enter_insert_after_new)
+    end)
+  end)
+
+  describe("setup function", function()
+    it("should overwrite defaults with user options", function()
+      local config = require("checkmate.config")
+
+      -- Default checks
+      assert.equals("□", config.options.todo_markers.unchecked)
+      assert.equals("✔", config.options.todo_markers.checked)
+
+      -- Call setup with new options
+      ---@diagnostic disable-next-line: missing-fields
+      config.setup({
+        todo_markers = {
+          unchecked = "⬜",
+          checked = "✅",
+        },
+        default_list_marker = "+",
+        enter_insert_after_new = false,
+      })
+
+      -- Check that options were updated
+      assert.equals("⬜", config.options.todo_markers.unchecked)
+      assert.equals("✅", config.options.todo_markers.checked)
+      assert.equals("+", config.options.default_list_marker)
+      assert.is_false(config.options.enter_insert_after_new)
+    end)
+  end)
+end)

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -1,0 +1,45 @@
+local M = {}
+
+-- Create a temporary file for testing
+function M.create_temp_file()
+  local temp_dir = vim.fn.tempname()
+  vim.fn.mkdir(temp_dir, "p")
+  local file_path = temp_dir .. "/test.todo"
+  return file_path
+end
+
+-- Read file contents directly (not via Neovim buffer)
+function M.read_file_content(file_path)
+  local f = io.open(file_path, "r")
+  if not f then
+    return nil
+  end
+  local content = f:read("*all")
+  f:close()
+  return content
+end
+
+-- Write content to file directly
+function M.write_file_content(file_path, content)
+  local f = io.open(file_path, "w")
+  if not f then
+    return false
+  end
+  f:write(content)
+  f:close()
+  return true
+end
+
+-- Helper function to create a test buffer with todo content
+function M.create_test_buffer(content)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(content, "\n"))
+  vim.bo[bufnr].filetype = "markdown"
+  return bufnr
+end
+
+function M.get_extmarks(bufnr, ns)
+  return vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+end
+
+return M

--- a/tests/checkmate/highlights_spec.lua
+++ b/tests/checkmate/highlights_spec.lua
@@ -1,0 +1,102 @@
+describe("Highlights", function()
+  local h = require("tests.checkmate.helpers")
+  -- Reset state before each test
+  before_each(function()
+    -- Reset the plugin state to ensure tests are isolated
+    _G.reset_state()
+  end)
+
+  describe("extmark highlighting", function()
+    it("should apply metadata tag highlights", function()
+      local config = require("checkmate.config")
+      local highlights = require("checkmate.highlights")
+      local unchecked = config.options.todo_markers.unchecked
+
+      -- Create test content with metadata
+      local content = [[
+# Test Todo List
+
+- ]] .. unchecked .. [[ Todo with @priority(high) metadata
+]]
+
+      -- Create test buffer
+      local bufnr = h.create_test_buffer(content)
+
+      -- Apply highlighting
+      highlights.apply_highlighting(bufnr, { debug_reason = "test" })
+
+      -- Get extmarks in checkmate namespace
+      local extmarks = h.get_extmarks(bufnr, config.ns)
+
+      -- Check for metadata highlights
+      local found_metadata = false
+
+      for _, mark in ipairs(extmarks) do
+        local details = mark[4]
+        if details and details.hl_group:match("^CheckmateMeta_") then
+          found_metadata = true
+          break
+        end
+      end
+
+      assert.is_true(found_metadata)
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+    end)
+
+    it("should display todo count when configured", function()
+      local config = require("checkmate.config")
+      local highlights = require("checkmate.highlights")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      -- Ensure todo count is enabled
+      config.options.show_todo_count = true
+
+      -- Create test content with parent and child todos
+      local content = [[
+# Test Todo List
+
+- ]] .. unchecked .. [[ Parent todo
+  - ]] .. unchecked .. [[ Child 1
+  - ]] .. checked .. [[ Child 2
+  - ]] .. unchecked .. [[ Child 3
+]]
+
+      -- Create test buffer
+      local bufnr = h.create_test_buffer(content)
+
+      -- Apply highlighting
+      highlights.apply_highlighting(bufnr, { debug_reason = "test" })
+
+      -- Get extmarks in checkmate namespace
+      local extmarks = h.get_extmarks(bufnr, config.ns)
+
+      -- Check for todo count indicator
+      local found_count = false
+
+      for _, mark in ipairs(extmarks) do
+        local details = mark[4]
+        if details and details.virt_text then
+          for _, text_part in ipairs(details.virt_text) do
+            -- Check if any virtual text has the expected format (1/3)
+            if text_part[1]:match("%d+/%d+") then
+              found_count = true
+              break
+            end
+          end
+        end
+      end
+
+      assert.is_true(found_count)
+
+      finally(function()
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+    end)
+  end)
+end)

--- a/tests/checkmate/parser_spec.lua
+++ b/tests/checkmate/parser_spec.lua
@@ -1,0 +1,449 @@
+describe("Parser", function()
+  -- Reset state before each test
+  before_each(function()
+    -- Reset the plugin state to ensure tests are isolated
+    _G.reset_state()
+  end)
+
+  -- Test todo item state detection
+  describe("todo item detection", function()
+    it("should detect unchecked todo items with default marker", function()
+      local parser = require("checkmate.parser")
+      local unchecked_marker = require("checkmate.config").options.todo_markers.unchecked
+      local line = "- " .. unchecked_marker .. " This is an unchecked todo"
+      local state = parser.get_todo_item_state(line)
+
+      assert.equals("unchecked", state)
+    end)
+
+    it("should detect checked todo items with default marker", function()
+      local parser = require("checkmate.parser")
+      local checked_marker = require("checkmate.config").options.todo_markers.checked
+      local line = "- " .. checked_marker .. " This is a checked todo"
+      local state = parser.get_todo_item_state(line)
+
+      assert.equals("checked", state)
+    end)
+
+    it("should detect unchecked todo items with various list markers", function()
+      local parser = require("checkmate.parser")
+      local unchecked_marker = require("checkmate.config").options.todo_markers.unchecked
+
+      -- Test with different list markers
+      local list_markers = { "-", "+", "*" }
+      for _, marker in ipairs(list_markers) do
+        local line = marker .. " " .. unchecked_marker .. " Todo with " .. marker
+        local state = parser.get_todo_item_state(line)
+        assert.equals("unchecked", state)
+      end
+    end)
+
+    it("should detect todo items with indentation", function()
+      local parser = require("checkmate.parser")
+      local unchecked_marker = require("checkmate.config").options.todo_markers.unchecked
+      local line = "    - " .. unchecked_marker .. " Indented todo"
+      local state = parser.get_todo_item_state(line)
+
+      assert.equals("unchecked", state)
+    end)
+
+    it("should detect todo items with ordered list markers", function()
+      local parser = require("checkmate.parser")
+      local unchecked_marker = require("checkmate.config").options.todo_markers.unchecked
+
+      -- Test with different numbered list formats
+      local formats = { "1. ", "1) ", "50. " }
+      for _, format in ipairs(formats) do
+        local line = format .. unchecked_marker .. " Numbered todo"
+        local state = parser.get_todo_item_state(line)
+        assert.equals("unchecked", state)
+      end
+    end)
+
+    it("should return nil for non-todo items", function()
+      local parser = require("checkmate.parser")
+      local unchecked_marker = require("checkmate.config").options.todo_markers.unchecked
+
+      local lines = {
+        "Regular text",
+        "- Just a list item",
+        "1. Numbered list item",
+        "* Another list item",
+        unchecked_marker .. " A todo marker but not a list item, therefore not a todo item",
+      }
+
+      for _, line in ipairs(lines) do
+        local state = parser.get_todo_item_state(line)
+        assert.is_nil(state)
+      end
+    end)
+
+    it("should handle custom todo markers from config", function()
+      local parser = require("checkmate.parser")
+      -- Temporarily modify config
+      local config = require("checkmate.config")
+      local original_markers = vim.deepcopy(config.options.todo_markers)
+
+      -- Set custom markers
+      config.options.todo_markers = {
+        unchecked = "[ ]",
+        checked = "[x]",
+      }
+
+      -- Test with custom markers
+      local lines = {
+        "- [ ] Custom unchecked",
+        "- [x] Custom checked",
+      }
+
+      local expected = {
+        "unchecked",
+        "checked",
+      }
+
+      for i, line in ipairs(lines) do
+        local state = parser.get_todo_item_state(line)
+        assert.equals(expected[i], state)
+      end
+
+      -- Restore original markers
+      config.options.todo_markers = original_markers
+    end)
+  end)
+
+  describe("extract_metadata", function()
+    it("should extract a single metadata tag", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task with @priority(high) tag"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      -- Check structure
+      assert.is_table(metadata)
+      assert.is_table(metadata.entries)
+      assert.is_table(metadata.by_tag)
+
+      -- Check content
+      assert.equals(1, #metadata.entries)
+      assert.equals("priority", metadata.entries[1].tag, "tag should have the correct name")
+      assert.equals("high", metadata.entries[1].value, "tag should have the correct value")
+      assert.same(metadata.entries[1], metadata.by_tag.priority)
+
+      -- Check range
+      assert.equals(0, metadata.entries[1].range.start.row)
+      assert.equals(16, metadata.entries[1].range.start.col, "tag should have correct start col")
+      assert.equals(0, metadata.entries[1].range["end"].row)
+      assert.equals(30, metadata.entries[1].range["end"].col, "tag should have correct end col")
+    end)
+
+    it("should extract multiple metadata tags", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @priority(high) @due(2023-04-01) @tags(important,urgent)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      -- Check basic structure
+      assert.equals(3, #metadata.entries)
+
+      -- Check first metadata tag
+      assert.equals("priority", metadata.entries[1].tag)
+      assert.equals("high", metadata.entries[1].value)
+
+      -- Check second metadata tag
+      assert.equals("due", metadata.entries[2].tag)
+      assert.equals("2023-04-01", metadata.entries[2].value)
+
+      -- Check third metadata tag
+      assert.equals("tags", metadata.entries[3].tag)
+      assert.equals("important,urgent", metadata.entries[3].value)
+
+      -- Check by_tag lookup
+      assert.same(metadata.entries[1], metadata.by_tag.priority)
+      assert.same(metadata.entries[2], metadata.by_tag.due)
+      assert.same(metadata.entries[3], metadata.by_tag.tags)
+    end)
+
+    it("should handle metadata with spaces in values", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @note(this is a note with spaces)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equals(1, #metadata.entries)
+      assert.equals("note", metadata.entries[1].tag)
+      assert.equals("this is a note with spaces", metadata.entries[1].value)
+    end)
+
+    it("should handle metadata with trailing and leading spaces in values", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @note(  spaced value  )"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equals(1, #metadata.entries)
+      assert.equals("note", metadata.entries[1].tag)
+      assert.equals("spaced value", metadata.entries[1].value) -- Spaces should be trimmed
+    end)
+
+    it("should properly track position_in_line", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @first(1) text in between @second(2)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equals(2, #metadata.entries)
+      assert.is_true(metadata.entries[1].position_in_line < metadata.entries[2].position_in_line)
+    end)
+
+    it("should handle metadata aliases", function()
+      local parser = require("checkmate.parser")
+      local config = require("checkmate.config")
+
+      -- Add an alias to the config
+      config.options.metadata.priority = config.options.metadata.priority or {}
+      config.options.metadata.priority.aliases = { "p", "pri" }
+
+      local line = "- □ Task @pri(high) @p(medium)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      -- Check that aliases are correctly marked
+      assert.equals(2, #metadata.entries)
+
+      assert.equals("pri", metadata.entries[1].tag)
+      assert.equals("priority", metadata.entries[1].alias_for)
+
+      assert.equals("p", metadata.entries[2].tag)
+      assert.equals("priority", metadata.entries[2].alias_for)
+
+      -- Check by_tag has entries for both alias and canonical name
+      assert.same(metadata.entries[1], metadata.by_tag.pri)
+      assert.same(metadata.entries[2], metadata.by_tag.p)
+      assert.same(metadata.entries[2], metadata.by_tag.priority) -- Last alias wins for canonical name
+    end)
+
+    it("should handle tag names with hyphens and underscores", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @tag-with-hyphens(value) @tag_with_underscores(value)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equals(2, #metadata.entries)
+      assert.equals("tag-with-hyphens", metadata.entries[1].tag)
+      assert.equals("tag_with_underscores", metadata.entries[2].tag)
+    end)
+
+    it("should return empty structure when no metadata present", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task with no metadata"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equals(0, #metadata.entries)
+      assert.same({}, metadata.by_tag)
+    end)
+
+    it("should correctly handle multiple tag instances of the same type", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @priority(low) Some text @priority(high)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      -- Should have both entries
+      assert.equals(2, #metadata.entries)
+
+      -- Last one should win in the by_tag lookup
+      assert.equals("high", metadata.by_tag.priority.value)
+    end)
+  end)
+
+  -- Test Markdown/Unicode conversion functions
+  describe("format conversion", function()
+    -- Test convert_markdown_to_unicode
+    describe("convert_markdown_to_unicode", function()
+      it("should convert markdown checkboxes to unicode symbols", function()
+        local parser = require("checkmate.parser")
+        local config = require("checkmate.config")
+
+        -- Create a test buffer with markdown content
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local markdown_lines = {
+          "# Todo List",
+          "",
+          "- [ ] Unchecked task",
+          "- [x] Checked task",
+          "- [X] Checked task with capital X",
+          "* [ ] Unchecked with asterisk",
+          "+ [x] Checked with plus",
+          "1. [ ] Numbered unchecked task",
+          "2. [x] Numbered checked task",
+          "",
+          "- Not a task",
+        }
+
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, markdown_lines)
+
+        -- Run the conversion
+        local was_modified = parser.convert_markdown_to_unicode(bufnr)
+
+        -- Should report modification happened
+        assert.is_true(was_modified)
+
+        -- Get the converted content
+        local converted_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        -- Check that appropriate conversions happened
+        local unchecked = config.options.todo_markers.unchecked
+        local checked = config.options.todo_markers.checked
+
+        assert.equals("# Todo List", converted_lines[1]) -- Heading unchanged
+        assert.equals("", converted_lines[2]) -- Empty line unchanged
+        assert.equals("- " .. unchecked .. " Unchecked task", converted_lines[3])
+        assert.equals("- " .. checked .. " Checked task", converted_lines[4])
+        assert.equals("- " .. checked .. " Checked task with capital X", converted_lines[5])
+        assert.equals("* " .. unchecked .. " Unchecked with asterisk", converted_lines[6])
+        assert.equals("+ " .. checked .. " Checked with plus", converted_lines[7])
+        assert.equals("1. " .. unchecked .. " Numbered unchecked task", converted_lines[8])
+        assert.equals("2. " .. checked .. " Numbered checked task", converted_lines[9])
+        assert.equals("", converted_lines[10]) -- Empty line unchanged
+        assert.equals("- Not a task", converted_lines[11]) -- Regular list item unchanged
+
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+    end)
+
+    -- Test convert_unicode_to_markdown
+    describe("convert_unicode_to_markdown", function()
+      it("should convert unicode symbols back to markdown checkboxes", function()
+        local parser = require("checkmate.parser")
+        local config = require("checkmate.config")
+        local unchecked = config.options.todo_markers.unchecked
+        local checked = config.options.todo_markers.checked
+
+        -- Create a test buffer with unicode content
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local unicode_lines = {
+          "# Todo List",
+          "",
+          "- " .. unchecked .. " Unchecked task",
+          "- " .. checked .. " Checked task",
+          "* " .. unchecked .. " Unchecked with asterisk",
+          "+ " .. checked .. " Checked with plus",
+          "1. " .. unchecked .. " Numbered unchecked task",
+          "2. " .. checked .. " Numbered checked task",
+          "",
+          "- Not a task",
+        }
+
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, unicode_lines)
+
+        -- Run the conversion
+        local was_modified = parser.convert_unicode_to_markdown(bufnr)
+
+        -- Should report modification happened
+        assert.is_true(was_modified)
+
+        -- Get the converted content
+        local converted_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        -- Check that appropriate conversions happened
+        assert.equals("# Todo List", converted_lines[1]) -- Heading unchanged
+        assert.equals("", converted_lines[2]) -- Empty line unchanged
+        assert.equals("- [ ] Unchecked task", converted_lines[3])
+        assert.equals("- [x] Checked task", converted_lines[4])
+        assert.equals("* [ ] Unchecked with asterisk", converted_lines[5])
+        assert.equals("+ [x] Checked with plus", converted_lines[6])
+        assert.equals("1. [ ] Numbered unchecked task", converted_lines[7])
+        assert.equals("2. [x] Numbered checked task", converted_lines[8])
+        assert.equals("", converted_lines[9]) -- Empty line unchanged
+        assert.equals("- Not a task", converted_lines[10]) -- Regular list item unchanged
+
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+
+      it("should handle indented todo items", function()
+        local parser = require("checkmate.parser")
+        local config = require("checkmate.config")
+        local unchecked = config.options.todo_markers.unchecked
+        local checked = config.options.todo_markers.checked
+
+        -- Create a test buffer with indented unicode content
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local unicode_lines = {
+          "# Todo List",
+          "- " .. unchecked .. " Parent task",
+          "  - " .. unchecked .. " Indented child task",
+          "    - " .. checked .. " Deeply indented task",
+        }
+
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, unicode_lines)
+
+        -- Run the conversion
+        local was_modified = parser.convert_unicode_to_markdown(bufnr)
+
+        -- Should report modification happened
+        assert.is_true(was_modified)
+
+        -- Get the converted content
+        local converted_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        -- Check that appropriate conversions happened
+        assert.equals("# Todo List", converted_lines[1])
+        assert.equals("- [ ] Parent task", converted_lines[2])
+        assert.equals("  - [ ] Indented child task", converted_lines[3])
+        assert.equals("    - [x] Deeply indented task", converted_lines[4])
+
+        -- Clean up
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end)
+    end)
+
+    it("should perform round-trip conversion correctly", function()
+      local parser = require("checkmate.parser")
+
+      -- Create a test buffer
+      local bufnr = vim.api.nvim_create_buf(false, true)
+
+      -- Original markdown content
+      local original_lines = {
+        "# Todo List",
+        "- [ ] Task 1",
+        "  - [x] Task 1.1",
+        "  - [ ] Task 1.2",
+        "- [x] Task 2",
+        "  * [ ] Task 2.1",
+        "  * [x] Task 2.2",
+      }
+
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, original_lines)
+
+      -- Convert markdown to unicode
+      parser.convert_markdown_to_unicode(bufnr)
+
+      -- Then convert unicode back to markdown
+      parser.convert_unicode_to_markdown(bufnr)
+
+      -- Get the final content
+      local final_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+      -- Verify round-trip produces original content
+      for i, line in ipairs(original_lines) do
+        assert.equals(line, final_lines[i])
+      end
+
+      -- Clean up
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+end)

--- a/tests/custom_reporter.lua
+++ b/tests/custom_reporter.lua
@@ -1,0 +1,245 @@
+-- custom_reporter.lua
+local term = require("term")
+local colors = term.colors
+local pretty = require("pl.pretty")
+local io_write = io.write
+local io_flush = io.flush
+local string_format = string.format
+local string_gsub = string.gsub
+
+local function println(msg)
+  io_write(msg .. "\n")
+end
+
+return function(options)
+  local busted = require("busted")
+  local handler = require("busted.outputHandlers.base")()
+
+  -- Parse options
+  local use_color = false
+  for _, v in ipairs(options.arguments or {}) do
+    if v == "color" then
+      use_color = true
+      break
+    end
+  end
+
+  -- Use busted's built-in term.color lib
+  local function green_mark()
+    return use_color and colors.green("✓") or "✓"
+  end
+  local function red_mark()
+    return use_color and colors.red("✗") or "✗"
+  end
+  local function yellow_mark()
+    return use_color and colors.yellow("→") or "→"
+  end
+
+  -- Add cyan for file names
+  local function cyan_text(text)
+    return use_color and colors.cyan(text) or text
+  end
+
+  -- Add dim for file paths
+  local function dim_text(text)
+    return use_color and colors.dim(text) or text
+  end
+
+  -- State
+  local indentLevel = 0
+  local passCount, failCount, skipCount = 0, 0, 0
+  local totalTests = 0
+  local fileCount = 0
+  local filesPassed = 0
+  local filesFailed = 0
+  local startTime = 0
+  local currentFile = nil
+  local currentFileFailed = false
+  local hasOutput = false -- Track if we've already output anything
+
+  handler.suiteReset = function()
+    indentLevel = 0
+    passCount, failCount, skipCount = 0, 0, 0
+    totalTests = 0
+    fileCount = 0
+    filesPassed = 0
+    filesFailed = 0
+    currentFile = nil
+    currentFileFailed = false
+    hasOutput = false
+    startTime = os.clock()
+  end
+
+  handler.suiteStart = function()
+    startTime = os.clock()
+    hasOutput = false
+  end
+
+  -- Handle file events
+  handler.fileStart = function(element)
+    currentFile = element.name
+    fileCount = fileCount + 1
+    currentFileFailed = false -- Reset for new file
+
+    if hasOutput then
+      -- Add blank line between files
+      println("")
+    end
+
+    -- Extract just the filename part with clever string patterns
+    local filename = currentFile:match("([^/\\]+)$") or currentFile
+
+    -- Output file header
+    println(cyan_text("● " .. filename))
+    println(dim_text("  " .. currentFile))
+    println("")
+
+    hasOutput = true
+    indentLevel = 1 -- Start the file's content at indent level 1
+  end
+
+  handler.fileEnd = function(element)
+    -- Mark file as passed or failed
+    if not currentFileFailed then
+      filesPassed = filesPassed + 1
+    else
+      filesFailed = filesFailed + 1
+    end
+
+    -- Add space after a file ends
+    println("")
+  end
+
+  -- Handle entering a describe/context block
+  handler.describeStart = function(element)
+    println(string.rep("  ", indentLevel) .. element.name)
+    indentLevel = indentLevel + 1
+  end
+
+  -- Handle exiting a describe/context block
+  handler.describeEnd = function(element)
+    indentLevel = math.max(indentLevel - 1, 0)
+  end
+
+  handler.testStart = function(element, parent)
+    totalTests = totalTests + 1
+  end
+
+  handler.testEnd = function(element, parent, status)
+    -- Extract just the test name (not the full hierarchy with describe blocks)
+    local name = element.name
+    local indent = string.rep("  ", indentLevel)
+
+    if status == "success" then
+      passCount = passCount + 1
+      println(indent .. green_mark() .. " " .. name)
+    elseif status == "pending" then
+      skipCount = skipCount + 1
+      println(indent .. yellow_mark() .. " " .. name .. " (skipped)")
+    elseif status == "failure" or status == "error" then
+      failCount = failCount + 1
+      currentFileFailed = true -- Mark the current file as failed
+      println(indent .. red_mark() .. " " .. name)
+
+      -- Get error details
+      local t = (status == "failure") and handler.failures[#handler.failures] or handler.errors[#handler.errors]
+      local msg = t.message or "Nil error"
+      if type(msg) ~= "string" then
+        msg = pretty.write(msg)
+      end
+
+      -- Indent error message with a different color and prefix
+      local error_indent = indent .. "  "
+      println(error_indent .. colors.red("❯ " .. element.name))
+
+      -- Format multi-line error message
+      local first_line = true
+      for line in msg:gmatch("[^\r\n]+") do
+        -- Skip duplicated test name in error
+        if first_line and line:match(element.name) then
+          -- Skip
+        else
+          println(error_indent .. "  " .. line)
+        end
+        first_line = false
+      end
+
+      -- Add file/line info if available in trace
+      if t.trace and t.trace.short_src and t.trace.currentline then
+        println(error_indent .. "  " .. dim_text("at " .. t.trace.short_src .. ":" .. t.trace.currentline))
+      end
+
+      println("") -- Add empty line after error
+    end
+
+    io_flush()
+  end
+
+  handler.error = function() end
+
+  handler.suiteEnd = function(element)
+    -- Only print summary at the very end
+    if element.descriptor ~= "suite" then
+      return
+    end
+
+    -- Calculate duration
+    local duration = os.clock() - startTime
+    local duration_text = string_format("%.2fs", duration)
+
+    -- Print summary border
+    println(
+      dim_text(
+        "─────────────────────────────────────────────────"
+      )
+    )
+
+    -- Print test files results
+    local result_text = string_format("Test Files  %d passed", filesPassed)
+
+    -- Only show failures if there were any
+    if filesFailed > 0 then
+      result_text = result_text .. string_format(", %d failed", filesFailed)
+    end
+
+    -- Total file count
+    result_text = result_text .. string_format(", %d total", fileCount)
+    println(result_text)
+
+    -- Print test counts
+    local test_text = string_format("Tests       %d passed", passCount)
+    if failCount > 0 then
+      test_text = test_text .. string_format(", %d failed", failCount)
+    end
+    if skipCount > 0 then
+      test_text = test_text .. string_format(", %d skipped", skipCount)
+    end
+    test_text = test_text .. string_format(", %d total", totalTests)
+    println(test_text)
+
+    -- Time info
+    println(string_format("Time        %s", duration_text))
+
+    -- Final status line
+    if failCount > 0 then
+      println(colors.red("\n✗ Tests failed. See above for more details."))
+    else
+      println(colors.green("\n✓ All tests passed!"))
+    end
+
+    io_flush()
+  end
+
+  -- Subscribe events
+  busted.subscribe({ "suite", "reset" }, handler.suiteReset)
+  busted.subscribe({ "suite", "start" }, handler.suiteStart)
+  busted.subscribe({ "file", "start" }, handler.fileStart)
+  busted.subscribe({ "file", "end" }, handler.fileEnd)
+  busted.subscribe({ "describe", "start" }, handler.describeStart)
+  busted.subscribe({ "describe", "end" }, handler.describeEnd)
+  busted.subscribe({ "test", "start" }, handler.testStart, { predicate = handler.cancelOnPending })
+  busted.subscribe({ "test", "end" }, handler.testEnd, { predicate = handler.cancelOnPending })
+  busted.subscribe({ "suite", "end" }, handler.suiteEnd)
+
+  return handler
+end

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -30,6 +30,7 @@ _G.reset_state = function()
   package.loaded["checkmate.util"] = nil
   package.loaded["checkmate.log"] = nil
   package.loaded["checkmate.api"] = nil
+  package.loaded["checkmate.highlights"] = nil
 
   -- Re-require the main module to reset its state
   return require("checkmate").setup()

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,36 @@
+-- Set up isolated test environment
+local test_dir = vim.fn.expand("%:p:h:h") -- Get the parent directory of the test directory
+local test_data_dir = test_dir .. "/.testdata"
+
+-- Override Neovim's data, state, and cache directories to keep tests isolated
+for _, dir_name in ipairs({ "data", "state", "cache" }) do
+  local path = test_data_dir .. "/" .. dir_name
+  vim.fn.mkdir(path, "p")
+  vim.env[("XDG_%s_HOME"):format(dir_name:upper())] = path
+end
+
+-- Add this plugin to the runtimepath
+vim.opt.runtimepath:append(test_dir)
+
+-- Add test dependencies to the runtimepath
+
+-- Disable random plugins that might affect testing
+vim.g.loaded_matchparen = 1
+vim.g.loaded_matchit = 1
+vim.g.loaded_logiPat = 1
+vim.g.loaded_rrhelper = 1
+vim.g.loaded_netrwPlugin = 1
+
+-- This function can be called by tests to reset the state between test runs
+_G.reset_state = function()
+  -- Reset any plugin state as needed
+  -- Example:
+  package.loaded["checkmate.config"] = nil
+  package.loaded["checkmate.parser"] = nil
+  package.loaded["checkmate.util"] = nil
+  package.loaded["checkmate.log"] = nil
+  package.loaded["checkmate.api"] = nil
+
+  -- Re-require the main module to reset its state
+  return require("checkmate").setup()
+end


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: buf writes are now atomic to maintain data integrity with markdown conversion
feat: added proper testing with Busted. Decent coverage of parser, api, and config
ci: updated release-please and added tests to CI. Will start using a separate release/vX.y.z branch
fix: adjusted log module's log levels table to match vim's
fix: added notifications for toggles attempted at invalid locations
END_COMMIT_OVERRIDE