### PR TITLE
fix(parser): critical bug fixed in parser

### DIFF
--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -293,28 +293,26 @@ function M.highlight_child_list_markers(bufnr, todo_item)
     -- Get the marker range
     local marker_start_row, marker_start_col, marker_end_row, marker_end_col = marker_node:range()
 
+    local raw_range = {
+      start = { row = marker_start_row, col = marker_start_col },
+      ["end"] = { row = marker_end_row, col = marker_end_col },
+    }
+
+    -- Get the adjusted range
+    local marker_range = require("checkmate.util").get_true_range(raw_range, bufnr)
+
     -- Only highlight markers within the todo item's range
-    if marker_start_row >= todo_item.range.start.row and marker_end_row <= todo_item.range["end"].row then
+    if
+      marker_range.start.row >= todo_item.range.start.row and marker_range["end"].row <= todo_item.range["end"].row
+    then
       local hl_group = marker_type == "ordered" and "CheckmateListMarkerOrdered" or "CheckmateListMarkerUnordered"
 
-      vim.api.nvim_buf_set_extmark(bufnr, config.ns, marker_start_row, marker_start_col, {
-        end_row = marker_end_row,
-        end_col = marker_end_col,
+      vim.api.nvim_buf_set_extmark(bufnr, config.ns, marker_range.start.row, marker_range.start.col, {
+        end_row = marker_range["end"].row,
+        end_col = marker_range["end"].col,
         hl_group = hl_group,
         priority = M.PRIORITY.LIST_MARKER,
       })
-
-      log.trace(
-        string.format(
-          "Highlighted child list marker at [%d,%d]-[%d,%d] with %s",
-          marker_start_row,
-          marker_start_col,
-          marker_end_row,
-          marker_end_col,
-          hl_group
-        ),
-        { module = "highlights" }
-      )
     end
 
     ::continue::
@@ -421,9 +419,13 @@ function M.highlight_content(bufnr, todo_item)
     )
 
     -- Process each line of the paragraph individually
-    for row = para_start_row, para_end_row do
+    for row = para_start_row, math.min(para_end_row, todo_item.range["end"].row) do
       local line = M.get_buffer_line(bufnr, row)
       local content_start = nil
+
+      -- For the end column, handle specially for the final row
+      local end_col = (row == todo_item.range["end"].row) and todo_item.range["end"].col
+        or #vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
 
       if is_first_para and row == para_start_row then
         -- Special handling for first line of first paragraph
@@ -442,9 +444,6 @@ function M.highlight_content(bufnr, todo_item)
       if content_start then
         -- Adjust to 0-based indexing
         content_start = content_start - 1
-
-        -- Calculate end column for this line
-        local end_col = (row == para_end_row) and para_end_col or #line
 
         -- Apply highlighting for this line
         vim.api.nvim_buf_set_extmark(bufnr, config.ns, row, content_start, {

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -299,7 +299,7 @@ function M.highlight_child_list_markers(bufnr, todo_item)
     }
 
     -- Get the adjusted range
-    local marker_range = require("checkmate.util").get_true_range(raw_range, bufnr)
+    local marker_range = require("checkmate.util").get_semantic_range(raw_range, bufnr)
 
     -- Only highlight markers within the todo item's range
     if

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -3,23 +3,23 @@ local M = {}
 ---@alias checkmate.TodoItemState "checked" | "unchecked"
 
 --- @class TodoMarkerInfo
---- @field position {row: integer, col: integer} Position of the marker
+--- @field position {row: integer, col: integer} Position of the marker (0-indexed)
 --- @field text string The marker text (e.g., "□" or "✓")
 
 --- @class ListMarkerInfo
---- @field node TSNode Treesitter node of the list marker
+--- @field node TSNode Treesitter node of the list marker (uses 0-indexed row/col coordinates)
 --- @field type "ordered"|"unordered" Type of list marker
 
 --- @class ContentNodeInfo
---- @field node TSNode Treesitter node containing content
+--- @field node TSNode Treesitter node containing content (uses 0-indexed row/col coordinates)
 --- @field type string Type of content node (e.g., "paragraph")
 
 ---@class checkmate.MetadataEntry
 ---@field tag string The tag name
 ---@field value string The value
----@field range {start: {row: integer, col: integer}, ['end']: {row: integer, col: integer}} Position range
+---@field range {start: {row: integer, col: integer}, ['end']: {row: integer, col: integer}} Position range (0-indexed)
 ---@field alias_for? string The canonical tag name if this is an alias
----@field position_in_line integer
+---@field position_in_line integer (1-indexed)
 
 ---@class checkmate.TodoMetadata
 ---@field entries checkmate.MetadataEntry[] List of metadata entries
@@ -28,12 +28,12 @@ local M = {}
 --- @class checkmate.TodoItem
 --- @field state checkmate.TodoItemState The todo state
 --- @field node TSNode The Treesitter node
---- Todo item range
---- 0 based index and end col are end exclusive
+--- Todo item's buffer range
+--- The end col is expected to be adjusted (get_semantic_range) so that it accurately reflects the end of the content
 --- @field range {start: {row: integer, col: integer}, ['end']: {row: integer, col: integer}}
 --- @field content_nodes ContentNodeInfo[] List of content nodes
---- @field todo_marker TodoMarkerInfo Information about the todo marker
---- @field list_marker ListMarkerInfo? Information about the list marker
+--- @field todo_marker TodoMarkerInfo Information about the todo marker (0-indexed position)
+--- @field list_marker ListMarkerInfo? Information about the list marker (0-indexed position)
 --- @field metadata checkmate.TodoMetadata | {} Metadata for this todo item
 --- @field todo_text string Text content of the todo item line (first line), may be truncated. Only for debugging.
 --- @field children string[] IDs of child todo items
@@ -378,10 +378,8 @@ function M.discover_todos(bufnr)
 
   -- First pass: Discover all todo items
   for _, node, _ in list_item_query:iter_captures(root, bufnr, 0, -1) do
-    -- Get node information
-    -- TS ranges are 0 indexed and the end col is end exclusive
+    -- Get node information (TS ranges are 0-indexed and end-exclusive)
     local start_row, start_col, end_row, end_col = node:range()
-
     local node_id = node:id()
 
     -- Get the first line to check if it's a todo item
@@ -398,13 +396,20 @@ function M.discover_todos(bufnr)
         ["end"] = { row = end_row, col = end_col },
       }
 
-      -- Get the adjusted range
-      local true_range = util.get_true_range(raw_range, bufnr)
+      -- Get the adjusted range with proper semantic boundaries
+      -- This more meaningful range encompasses the todo content better than the quirky Treesitter technical range for a node
+      local semantic_range = util.get_semantic_range(raw_range, bufnr)
 
       -- Find the todo marker position
       local todo_marker = todo_state == "checked" and config.options.todo_markers.checked
         or config.options.todo_markers.unchecked
+
+      -- Find marker position, defaulting to -1 if not found
+      local marker_col = -1
       local todo_marker_pos = first_line:find(todo_marker, 1, true)
+      if todo_marker_pos then
+        marker_col = todo_marker_pos - 1 -- Adjust for 0-indexing
+      end
 
       local metadata = M.extract_metadata(first_line, start_row)
 
@@ -412,20 +417,20 @@ function M.discover_todos(bufnr)
       todo_map[node_id] = {
         state = todo_state,
         node = node,
-        range = true_range,
-        todo_text = vim.api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, false)[1],
+        range = semantic_range,
+        todo_text = first_line,
         content_nodes = {},
         todo_marker = {
           position = {
             row = start_row,
-            col = todo_marker_pos and todo_marker_pos - 1 or -1,
+            col = marker_col,
           },
           text = todo_marker,
         },
         list_marker = nil, -- Will be set by find_list_marker_info
         metadata = metadata,
-        children = {},
-        parent_id = nil, -- Will be set in second pass
+        children = {}, -- Will be set in second pass, if applicable
+        parent_id = nil, -- Will be set in second pass, if applicable
       }
 
       -- Find and store list marker information
@@ -517,14 +522,17 @@ function M.update_content_nodes(node, bufnr, todo_item)
 end
 
 ---Build the hierarchy of todo items based on indentation
----The Treesitter tree-based list item hierachy doesn't always match what you might expect in terms of parent/child
----relationships. The user expects parent/child order based on indentation and thus we build the todo hierarchy
----based on indentation differences rather than relying on TS tree.
----The natural rule is: "your parent is the closest todo item above you with less indentation"
+---
+---The Treesitter tree-based list item hierarchy doesn't always match the expected parent/child
+---relationships from a user perspective. Users expect parent/child relationships based on
+---indentation, so we build the todo hierarchy based on indentation differences rather than
+---relying solely on the Treesitter tree structure.
+---
+---The rule is: "your parent is the closest todo item above you with less indentation"
+---
 ---@param todo_map table<string, checkmate.TodoItem>
+---@return table<string, checkmate.TodoItem> result The updated todo map with hierarchy information
 function M.build_todo_hierarchy(todo_map)
-  local log = require("checkmate.log")
-
   -- Reset all children arrays and parent_ids
   for _, item in pairs(todo_map) do
     item.children = {}

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -285,6 +285,34 @@ function M.get_sorted_todo_list(todo_map)
   return todo_list
 end
 
+--- Interprets a TS range's true end position, accounting for end_col = 0
+---@param range {start: {row: integer, col: integer}, ['end']: {row: integer, col: integer}}
+---@param bufnr integer Buffer number
+---@return {start: {row: integer, col: integer}, ['end']: {row: integer, col: integer}} Adjusted range
+function M.get_true_range(range, bufnr)
+  -- Create a new range object to avoid modifying the original
+  local new_range = {
+    start = { row = range.start.row, col = range.start.col },
+    ["end"] = { row = range["end"].row, col = range["end"].col },
+  }
+
+  -- If end_col is 0, it means we're at the start of the next line
+  -- which actually means the end of the previous line
+  if new_range["end"].col == 0 then
+    new_range["end"].row = new_range["end"].row - 1
+  end
+
+  -- For both cases (end_col=0 or multi-line), set end column to end of line
+  if new_range["end"].col == 0 or new_range.start.row < new_range["end"].row then
+    local lines = vim.api.nvim_buf_get_lines(bufnr, new_range["end"].row, new_range["end"].row + 1, false)
+    if #lines > 0 then
+      new_range["end"].col = #lines[1]
+    end
+  end
+
+  return new_range
+end
+
 -- Cursor helper
 M.Cursor = {}
 

--- a/tests/checkmate/parser_spec.lua
+++ b/tests/checkmate/parser_spec.lua
@@ -1,8 +1,360 @@
 describe("Parser", function()
+  local h = require("tests.checkmate.helpers")
+
+  lazy_setup(function()
+    -- Hide nvim_echo from polluting test output
+    stub(vim.api, "nvim_echo")
+  end)
+
+  lazy_teardown(function()
+    ---@diagnostic disable-next-line: undefined-field
+    vim.api.nvim_echo:revert()
+  end)
+
   -- Reset state before each test
   before_each(function()
     -- Reset the plugin state to ensure tests are isolated
     _G.reset_state()
+  end)
+
+  -- Helper to find a specific todo in the todo_map by pattern matching on the todo text
+  local function find_todo_by_text(todo_map, pattern)
+    for _, todo in pairs(todo_map) do
+      if todo.todo_text:match(pattern) then
+        return todo
+      end
+    end
+    return nil
+  end
+
+  -- Helper to verify todo range is consistent with its content
+  local function verify_todo_range_matches_content(bufnr, todo)
+    -- End row should not exceed buffer line count
+    local line_count = vim.api.nvim_buf_line_count(bufnr)
+    assert.is_true(todo.range["end"].row < line_count)
+
+    -- Start row should be less than or equal to end row
+    assert.is_true(todo.range.start.row <= todo.range["end"].row)
+
+    -- If multi-line, end column should be at end of line
+    if todo.range.start.row < todo.range["end"].row then
+      local end_line = vim.api.nvim_buf_get_lines(bufnr, todo.range["end"].row, todo.range["end"].row + 1, false)[1]
+      assert.equals(#end_line, todo.range["end"].col, "Multi-line todo end column should be at line end")
+    end
+
+    -- Todo marker should be within text bounds
+    assert.is_true(todo.todo_marker.position.row >= todo.range.start.row)
+    assert.is_true(todo.todo_marker.position.row <= todo.range["end"].row)
+    assert.is_true(todo.todo_marker.position.col >= 0)
+  end
+
+  describe("todo discovery", function()
+    it("should calculate correct ranges for todos with different lengths", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local unchecked = config.options.todo_markers.unchecked
+
+      local content = [[
+# Range Test
+- ]] .. unchecked .. [[ Single line todo
+- ]] .. unchecked .. [[ Multi-line todo
+  with one continuation
+- ]] .. unchecked .. [[ Three line
+  todo with
+  two continuations]]
+
+      local bufnr = h.create_test_buffer(content)
+      local todo_map = parser.discover_todos(bufnr)
+
+      -- Find our test todos by text pattern
+      local single_line = find_todo_by_text(todo_map, "Single line")
+      local multi_line = find_todo_by_text(todo_map, "Multi%-line")
+      local three_line = find_todo_by_text(todo_map, "Three line")
+
+      assert.is_not_nil(single_line)
+      ---@cast single_line checkmate.TodoItem
+      assert.is_not_nil(multi_line)
+      ---@cast multi_line checkmate.TodoItem
+      assert.is_not_nil(three_line)
+      ---@cast three_line checkmate.TodoItem
+
+      -- Single line tests
+      assert.equals(1, single_line.range.start.row, "Single line todo should start at line 1")
+      assert.equals(1, single_line.range["end"].row, "Single line todo should end at line 1")
+
+      -- Multi-line tests (2 lines)
+      assert.equals(2, multi_line.range.start.row, "Multi-line todo should start at line 2")
+      assert.equals(3, multi_line.range["end"].row, "Multi-line todo should end at line 3")
+
+      -- Three-line tests
+      assert.equals(4, three_line.range.start.row, "Three-line todo should start at line 4")
+      assert.equals(6, three_line.range["end"].row, "Three-line todo should end at line 6")
+
+      -- Additional validation for each todo
+      verify_todo_range_matches_content(bufnr, single_line)
+      verify_todo_range_matches_content(bufnr, multi_line)
+      verify_todo_range_matches_content(bufnr, three_line)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    -- Test complex hierarchical todos with various indentation patterns
+    it("should correctly handle complex hierarchical todos with various indentations", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      local content = [[
+# Complex Hierarchy
+- ]] .. unchecked .. [[ Level 1 todo
+  - ]] .. checked .. [[ Level 2 todo with 2-space indent
+    - ]] .. unchecked .. [[ Level 3 todo with 4-space indent
+      - ]] .. checked .. [[ Level 4 todo with 6-space indent
+        - ]] .. unchecked .. [[ Level 5 todo with 8-space indent
+  - ]] .. unchecked .. [[ Another Level 2 with 2-space indent
+   - ]] .. unchecked .. [[ Irregular indentation (3-spaces)
+    - ]] .. unchecked .. [[ Back to 4-space indent
+  - ]] .. checked .. [[ Tab indentation
+  	- ]] .. unchecked .. [[ Double tab indentation
+
+- ]] .. unchecked .. [[ Another top-level todo
+    - ]] .. checked .. [[ Direct jump to Level 3 (unusual)
+- ]] .. unchecked .. [[ Todo with empty content after marker
+- ]] .. unchecked .. [[ ]]
+
+      local bufnr = h.create_test_buffer(content)
+      local todo_map = parser.discover_todos(bufnr)
+
+      -- First verify total count (updated for new todos)
+      local total_todos = 0
+      for _ in pairs(todo_map) do
+        total_todos = total_todos + 1
+      end
+      assert.equals(14, total_todos, "Should find all todos in total")
+
+      -- Find top-level todos
+      local level1_todo = find_todo_by_text(todo_map, "Level 1 todo")
+      local another_top = find_todo_by_text(todo_map, "Another top%-level todo")
+      local empty_content = find_todo_by_text(todo_map, "Todo with empty content")
+      local empty_line = find_todo_by_text(todo_map, "- " .. unchecked .. " %s*$") -- Empty line after marker
+
+      assert.is_not_nil(level1_todo)
+      ---@cast level1_todo checkmate.TodoItem
+      assert.is_not_nil(another_top)
+      ---@cast another_top checkmate.TodoItem
+      assert.is_not_nil(empty_content)
+      ---@cast empty_content checkmate.TodoItem
+      assert.is_not_nil(empty_line)
+      ---@cast empty_line checkmate.TodoItem
+
+      -- Verify parent-child relationships
+      assert.equals(3, #level1_todo.children, "First level 1 todo should have 3 children")
+      assert.equals(1, #another_top.children, "Second level 1 todo should have 1 child")
+      assert.equals(0, #empty_content.children, "Empty content todo should have 0 children")
+      assert.equals(0, #empty_line.children, "Empty line todo should have 0 children")
+
+      -- Find level 2 todo
+      local level2_todo = nil
+      for _, child_id in ipairs(level1_todo.children) do
+        local child = todo_map[child_id]
+        if child.todo_text:match("Level 2 todo") then
+          level2_todo = child
+          break
+        end
+      end
+
+      assert.is_not_nil(level2_todo)
+      ---@cast level2_todo checkmate.TodoItem
+      assert.equals(1, #level2_todo.children, "Level 2 todo should have 1 child")
+
+      -- Find level 3 via level 2
+      local level3_todo = nil
+      for _, child_id in ipairs(level2_todo.children) do
+        level3_todo = todo_map[child_id]
+        break
+      end
+
+      assert.is_not_nil(level3_todo)
+      ---@cast level3_todo checkmate.TodoItem
+      assert.equals(1, #level3_todo.children, "Level 3 todo should have 1 child")
+
+      -- Find level 4 and verify it has level 5 child
+      local level4_todo = nil
+      for _, child_id in ipairs(level3_todo.children) do
+        level4_todo = todo_map[child_id]
+        break
+      end
+
+      assert.is_not_nil(level4_todo)
+      ---@cast level4_todo checkmate.TodoItem
+      assert.equals(1, #level4_todo.children, "Level 4 todo should have 1 child")
+
+      -- Verify deep nesting to level 5
+      local level5_todo = find_todo_by_text(todo_map, "Level 5 todo")
+      assert.is_not_nil(level5_todo)
+      ---@cast level5_todo checkmate.TodoItem
+      assert.equals(level4_todo.node:id(), level5_todo.parent_id, "Level 5 should be child of Level 4")
+
+      -- Verify irregular indentation is still properly nested
+      local irregular = find_todo_by_text(todo_map, "Irregular indentation")
+      assert.is_not_nil(irregular)
+      ---@cast irregular checkmate.TodoItem
+      assert.is_true(irregular.parent_id ~= nil)
+
+      -- Verify tab indentation is handled properly
+      local tab_indent = find_todo_by_text(todo_map, "Tab indentation")
+      local double_tab = find_todo_by_text(todo_map, "Double tab indentation")
+      assert.is_not_nil(tab_indent)
+      ---@cast tab_indent checkmate.TodoItem
+      assert.is_not_nil(double_tab)
+      ---@cast double_tab checkmate.TodoItem
+
+      -- Tab indented item should be child of Another Level 2
+      local another_level2 = find_todo_by_text(todo_map, "Another Level 2")
+      assert.is_not_nil(another_level2)
+      ---@cast another_level2 checkmate.TodoItem
+
+      assert.equals(level1_todo.node:id(), tab_indent.parent_id, "Tab indented item should be child of Another Level 2")
+      assert.equals(tab_indent.node:id(), double_tab.parent_id, "Double tab should be child of single tab")
+
+      -- Verify unusual hierarchy jump (top level to level 3)
+      local unusual = find_todo_by_text(todo_map, "Direct jump to Level 3")
+      assert.is_not_nil(unusual)
+      ---@cast unusual checkmate.TodoItem
+      assert.equals(another_top.node:id(), unusual.parent_id, "Unusual jump should be direct child despite indentation")
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("should build correct parent-child relationships with mixed list types", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      local content = [[
+# Mixed List Types
+- ]] .. unchecked .. [[ Parent with dash
+  * ]] .. unchecked .. [[ Child with asterisk
+  + ]] .. checked .. [[ Child with plus
+    - ]] .. unchecked .. [[ Grandchild with dash
+1. ]] .. unchecked .. [[ Ordered parent
+  2. ]] .. checked .. [[ Ordered child
+    3. ]] .. unchecked .. [[ Ordered grandchild
+  * ]] .. unchecked .. [[ Unordered child with asterisk in ordered parent
+]]
+
+      local bufnr = h.create_test_buffer(content)
+      local todo_map = parser.discover_todos(bufnr)
+
+      -- Find todos with different list types
+      local parent_dash = find_todo_by_text(todo_map, "Parent with dash")
+      local child_asterisk = find_todo_by_text(todo_map, "Child with asterisk")
+      local child_plus = find_todo_by_text(todo_map, "Child with plus")
+      local ordered_parent = find_todo_by_text(todo_map, "Ordered parent")
+      local ordered_child = find_todo_by_text(todo_map, "Ordered child")
+      local mixed_child = find_todo_by_text(todo_map, "Unordered child with asterisk")
+
+      assert.is_not_nil(parent_dash)
+      ---@cast parent_dash checkmate.TodoItem
+      assert.is_not_nil(child_asterisk)
+      ---@cast child_asterisk checkmate.TodoItem
+      assert.is_not_nil(child_plus)
+      ---@cast child_plus checkmate.TodoItem
+      assert.is_not_nil(ordered_parent)
+      ---@cast ordered_parent checkmate.TodoItem
+      assert.is_not_nil(ordered_child)
+      ---@cast ordered_child checkmate.TodoItem
+      assert.is_not_nil(mixed_child)
+      ---@cast mixed_child checkmate.TodoItem
+
+      -- Verify parent-child relationships
+      assert.equals(2, #parent_dash.children, "Parent with dash should have 2 children")
+      assert.equals(2, #ordered_parent.children, "Ordered parent should have 2 children")
+
+      -- Verify mixed list marker relationships
+      assert.equals(
+        parent_dash.node:id(),
+        child_asterisk.parent_id,
+        "Child with asterisk should be child of parent with dash"
+      )
+      assert.equals(parent_dash.node:id(), child_plus.parent_id, "Child with plus should be child of parent with dash")
+      assert.equals(
+        ordered_parent.node:id(),
+        ordered_child.parent_id,
+        "Ordered child should be child of ordered parent"
+      )
+      assert.equals(
+        ordered_parent.node:id(),
+        mixed_child.parent_id,
+        "Unordered child should be child of ordered parent"
+      )
+
+      -- Verify list marker type is correctly detected
+      assert.equals("unordered", parent_dash.list_marker.type, "Dash should be unordered")
+      assert.equals("unordered", child_asterisk.list_marker.type, "Asterisk should be unordered")
+      assert.equals("unordered", child_plus.list_marker.type, "Plus should be unordered")
+      assert.equals("ordered", ordered_parent.list_marker.type, "Numbered should be ordered")
+      assert.equals("ordered", ordered_child.list_marker.type, "Numbered child should be ordered")
+      assert.equals("unordered", mixed_child.list_marker.type, "Asterisk should be unordered even in ordered parent")
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("should handle edge cases", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      local content = [[
+- ]] .. unchecked .. [[ Todo at document start
+Some non-todo content in between
+- ]] .. unchecked .. [[ Parent todo
+  - ]] .. checked .. [[ Checked child
+  - ]] .. unchecked .. [[ Unchecked child
+Line that should not affect parent-child relationship
+  Not a todo but indented
+- ]] .. unchecked .. [[ Todo at document end]]
+
+      local bufnr = h.create_test_buffer(content)
+      local todo_map = parser.discover_todos(bufnr)
+
+      -- Find todos in edge positions
+      local start_todo = find_todo_by_text(todo_map, "Todo at document start")
+      local parent_todo = find_todo_by_text(todo_map, "Parent todo")
+      local checked_child = find_todo_by_text(todo_map, "Checked child")
+      local unchecked_child = find_todo_by_text(todo_map, "Unchecked child")
+      local end_todo = find_todo_by_text(todo_map, "Todo at document end")
+
+      assert.is_not_nil(start_todo)
+      ---@cast start_todo checkmate.TodoItem
+      assert.is_not_nil(parent_todo)
+      ---@cast parent_todo checkmate.TodoItem
+      assert.is_not_nil(checked_child)
+      ---@cast checked_child checkmate.TodoItem
+      assert.is_not_nil(unchecked_child)
+      ---@cast unchecked_child checkmate.TodoItem
+      assert.is_not_nil(end_todo)
+      ---@cast end_todo checkmate.TodoItem
+
+      -- Verify edge position todos
+      assert.is_nil(start_todo.parent_id, "Todo at document start should have no parent")
+      assert.is_nil(end_todo.parent_id, "Todo at document end should have no parent")
+
+      -- Verify parent-child with content in between
+      assert.equals(2, #parent_todo.children, "Parent todo should have 2 children despite non-todo content")
+      assert.equals(parent_todo.node:id(), checked_child.parent_id, "Checked child should be child of parent")
+      assert.equals(parent_todo.node:id(), unchecked_child.parent_id, "Unchecked child should be child of parent")
+
+      -- Verify checked state is maintained in hierarchy
+      assert.equals("unchecked", parent_todo.state, "Parent todo should be unchecked")
+      assert.equals("checked", checked_child.state, "Child should remain checked even if parent is unchecked")
+      assert.equals("unchecked", unchecked_child.state, "Unchecked child should be unchecked")
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
   end)
 
   -- Test todo item state detection
@@ -443,6 +795,129 @@ describe("Parser", function()
       end
 
       -- Clean up
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  describe("performance", function()
+    -- Test very large and complex document
+    it("should handle large documents with many todos at different levels", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      -- Generate a large document with many todos
+      local content_lines = { "# Large Document Test" }
+
+      -- Helper to generate todo content
+      local function add_todo(level, state, text, metadata)
+        local indent = string.rep("  ", level - 1)
+        local marker = state == "checked" and checked or unchecked
+        local meta_text = metadata or ""
+        if metadata then
+          meta_text = " " .. meta_text
+        end
+
+        table.insert(content_lines, indent .. "- " .. marker .. " " .. text .. meta_text)
+      end
+
+      -- Add lots of todos with various properties
+      for i = 1, 5 do -- 5 top level sections
+        table.insert(content_lines, "")
+        table.insert(content_lines, "## Section " .. i)
+
+        for j = 1, 10 do -- 10 top level todos per section
+          local top_state = (j % 3 == 0) and "checked" or "unchecked"
+          add_todo(1, top_state, "Top level todo " .. i .. "." .. j)
+
+          -- Add some children to each top level todo
+          for k = 1, 3 do
+            local child_state = (k % 2 == 0) and "checked" or "unchecked"
+            add_todo(2, child_state, "Child todo " .. i .. "." .. j .. "." .. k)
+
+            -- Add grandchildren to some children
+            if k % 2 == 1 then
+              add_todo(3, "unchecked", "Grandchild todo " .. i .. "." .. j .. "." .. k .. ".1", "@priority(high)")
+              add_todo(3, "checked", "Grandchild todo " .. i .. "." .. j .. "." .. k .. ".2", "@due(2025-06-01)")
+            end
+          end
+        end
+      end
+
+      local content = table.concat(content_lines, "\n")
+      local bufnr = h.create_test_buffer(content)
+
+      -- Measure performance
+      local start_time = vim.fn.reltime()
+      local todo_map = parser.discover_todos(bufnr)
+      local end_time = vim.fn.reltimefloat(vim.fn.reltime(start_time))
+
+      -- Check we found the expected number of todos
+      local total_todos = 0
+      for _ in pairs(todo_map) do
+        total_todos = total_todos + 1
+      end
+
+      -- We should have:
+      -- 5 sections × 10 top level todos = 50 top level
+      -- 50 top level × 3 children = 150 children
+      -- Half of children get 2 grandchildren each = 75 × 2 = 150 grandchildren
+      -- Total: 50 + 150 + 150 = 350 todos
+      assert.is_true(total_todos >= 300)
+
+      -- Check structure - select a specific known todo and verify its hierarchy
+      local section3_todo2 = nil
+      for _, todo in pairs(todo_map) do
+        if todo.todo_text:match("Top level todo 3%.2$") then
+          section3_todo2 = todo
+          break
+        end
+      end
+
+      assert.is_not_nil(section3_todo2)
+      ---@cast section3_todo2 checkmate.TodoItem
+      assert.equals(3, #section3_todo2.children, "Section 3 todo 2 should have 3 children")
+
+      -- Pick one child and verify its properties
+      local child_id = section3_todo2.children[1]
+      local child = todo_map[child_id]
+
+      assert.is_not_nil(child)
+      assert.equals(section3_todo2.node:id(), child.parent_id, "Child's parent_id should match parent's node id")
+
+      -- Spot check some selected todos to ensure they all have valid ranges
+      local count = 0
+      for _, todo in pairs(todo_map) do
+        if count % 20 == 0 then -- Check every 20th todo
+          verify_todo_range_matches_content(bufnr, todo)
+        end
+        count = count + 1
+      end
+
+      -- Verify that todos with metadata have it properly extracted
+      local found_metadata = 0
+      for _, todo in pairs(todo_map) do
+        if #todo.metadata.entries > 0 then
+          found_metadata = found_metadata + 1
+
+          -- Verify at least one priority and one due date metadata
+          if todo.metadata.by_tag.priority then
+            assert.equals("high", todo.metadata.by_tag.priority.value, "Priority should be high")
+          end
+          if todo.metadata.by_tag.due then
+            assert.equals("2025-06-01", todo.metadata.by_tag.due.value, "Due date should be correct")
+          end
+        end
+      end
+
+      assert.is_true(found_metadata > 0)
+
+      -- print("large doc time: " .. end_time * 1000 .. "ms")
+
+      -- Performance should be reasonable even for large documents
+      assert.is_true(end_time < 0.1) -- 100 ms
+
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
   end)


### PR DESCRIPTION
A couple nuanced behaviors of Vim/neovim and Treesitter that lead to subtle bugs:

- Differences in 0 versus 1-based indexing of ranges. This is coupled with Lua tables being 1-indexed as well to add some confusion
  - Treesitter uses 0-indexed row and column positions, while most Vim/Neovim operations use 0-index but some use 1-indexed rows.
- Additionally, Treesitter has a peculiar behavior with the end col of nodes
  - The treesitter end col is "end exclusive" meaning the end index isn't actually included in the node and the actual content would end at end col - 1
  - When a node ends at the end of a line, TreeSitter often represents this as position (next_row, 0) rather than (current_row, end_of_line)

Thus the need to transform Treesitter's technical representation into semantically meaningful ranges that:
- Accurately reflect todo item boundaries: Todo items should span from their beginning to the true end of their content.
- Support proper highlighting: We need to highlight the entire content of a todo item, which requires precise range information.