### PR TITLE
Major refactor: diff hunks and bulk processing

### DIFF
--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -342,7 +342,8 @@ function M.process_buffer(bufnr, reason)
 
       local start_time = vim.uv.hrtime() / 1000000
 
-      local todo_map = parser.discover_todos(bufnr)
+      -- local todo_map = parser.discover_todos(bufnr)
+      local todo_map = parser.get_todo_map(bufnr)
       parser.convert_markdown_to_unicode(bufnr)
 
       require("checkmate.highlights").apply_highlighting(

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -572,7 +572,7 @@ function M.archive_todos(opts)
   -- discover todos and current archive block boundaries
   ---------------------------------------------------------------------------
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_map = parser.discover_todos(bufnr)
+  local todo_map = parser.get_todo_map(bufnr)
   local sorted_todos = util.get_sorted_todo_list(todo_map)
   local current_buf_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
@@ -820,7 +820,7 @@ function M.collect_todo_items_from_selection(is_visual)
   local items = {}
 
   -- Pre-parse all todos once
-  local full_map = parser.discover_todos(bufnr)
+  local full_map = parser.get_todo_map(bufnr)
 
   if is_visual then
     -- Exit visual mode first

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -1148,7 +1148,7 @@ function M.compute_diff_remove_metadata(items, meta_name)
   for _, item in ipairs(items) do
     table.insert(rows, item.todo_marker.position.row)
   end
-  local lines = util.get_buffer_lines(bufnr, rows)
+  local lines = util.batch_get_lines(bufnr, rows)
 
   for _, todo_item in ipairs(items) do
     local row = todo_item.range.start.row
@@ -1246,7 +1246,7 @@ function M.compute_diff_remove_all_metadata(items)
   for _, item in ipairs(items) do
     table.insert(rows, item.todo_marker.position.row)
   end
-  local lines = util.get_buffer_lines(bufnr, rows)
+  local lines = util.batch_get_lines(bufnr, rows)
 
   for _, todo_item in ipairs(items) do
     if todo_item.metadata and todo_item.metadata.entries and #todo_item.metadata.entries ~= 0 then

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -806,6 +806,7 @@ end
 --- Collect todo items under cursor or visual selection
 ---@param is_visual boolean Whether to collect items in visual selection (true) or under cursor (false)
 ---@return checkmate.TodoItem[] items
+---@return table<integer, checkmate.TodoItem> todo_map
 function M.collect_todo_items_from_selection(is_visual)
   local parser = require("checkmate.parser")
   local config = require("checkmate.config")
@@ -823,8 +824,14 @@ function M.collect_todo_items_from_selection(is_visual)
   if is_visual then
     -- Exit visual mode first
     vim.cmd([[execute "normal! \<Esc>"]])
-    local start_line = vim.fn.line("'<") - 1
-    local end_line = vim.fn.line("'>") - 1
+    -- local start_line = vim.fn.line("'<") - 1
+    -- local end_line = vim.fn.line("'>") - 1
+    local mark_start = vim.api.nvim_buf_get_mark(bufnr, "<")
+    local mark_end = vim.api.nvim_buf_get_mark(bufnr, ">")
+
+    -- convert from 1-based mark to 0-based rows
+    local start_line = mark_start[1] - 1
+    local end_line = mark_end[1] - 1
 
     -- Pre-build lookup table for faster todo item location
     local row_to_todo = {}
@@ -866,7 +873,7 @@ function M.collect_todo_items_from_selection(is_visual)
 
   profiler.stop("api.collect_todo_items_from_selection")
 
-  return items
+  return items, full_map
 end
 
 --- Create a hunk that replaces only the todo marker character

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -1122,6 +1122,10 @@ function M.collect_todo_items_from_selection(is_visual)
   local parser = require("checkmate.parser")
   local config = require("checkmate.config")
   local util = require("checkmate.util")
+  local profiler = require("checkmate.profiler")
+
+  profiler.start("api.collect_todo_items_from_selection")
+
   local bufnr = vim.api.nvim_get_current_buf()
   local items = {}
   -- Pre-parse all todos once
@@ -1164,6 +1168,8 @@ function M.collect_todo_items_from_selection(is_visual)
       table.insert(items, todo)
     end
   end
+
+  profiler.stop("api.collect_todo_items_from_selection")
 
   return items
 end
@@ -1704,6 +1710,9 @@ end
 
 -- Process all pending changes into diff hunks
 function M._process_pending_changes(bufnr, pending_changes)
+  local profiler = require("checkmate.profiler")
+
+  profiler.start("api._process_pending_changes")
   local hunks = {}
   local changes_by_type = {}
 
@@ -1773,6 +1782,8 @@ function M._process_pending_changes(bufnr, pending_changes)
       end
     end
   end
+
+  profiler.stop("api._process_pending_changes")
 
   return hunks
 end

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -609,7 +609,8 @@ function M.archive_todos(opts)
   local archived_root_cnt = 0
 
   for _, entry in ipairs(sorted_todos) do
-    local todo = entry ---@type checkmate.TodoItem
+    ---@cast entry {id: integer, item: checkmate.TodoItem}
+    local todo = entry.item
     local id = entry.id
     local in_arch = archive_start_row
       and todo.range.start.row > archive_start_row

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -1119,7 +1119,6 @@ function M.add_metadata(items, params, ctx)
   if #items == 1 and to_jump then
     local item = items[1]
     local meta_config = config.options.metadata[to_jump.meta_name]
-    print("will jump")
     M._handle_metadata_cursor_jump(vim.api.nvim_get_current_buf(), item, to_jump.meta_name, meta_config)
   end
 

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -7,7 +7,7 @@
 local M = {}
 
 -- Set to true during development to include debug commands
-local INCLUDE_DEBUG_COMMANDS = false
+local INCLUDE_DEBUG_COMMANDS = true
 
 -- Regular commands that are always available
 ---@type CheckmateCommand[]

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -637,10 +637,6 @@ function M.stop()
           local linter = require("checkmate.linter")
           linter.disable(bufnr)
         end
-        -- Clear highlights and caches
-        if package.loaded["checkmate.highlights"] then
-          require("checkmate.highlights").clear_line_cache(bufnr)
-        end
 
         -- Reset buffer state
         vim.b[bufnr].checkmate_setup_complete = nil

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -566,6 +566,11 @@ function M.notify_config_changed()
     require("checkmate.linter").setup(M.options.linter)
   end
 
+  -- Update parser's patterns
+  if package.loaded["checkmate.parser"] then
+    require("checkmate.parser").clear_pattern_cache() -- clears the pattern cache in case todo markers were changed in config
+  end
+
   -- Refresh highlights
   if package.loaded["checkmate.highlights"] then
     require("checkmate.highlights").setup_highlights()

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -4,6 +4,7 @@ local M = {}
 
 -- Namespace for plugin-related state
 M.ns = vim.api.nvim_create_namespace("checkmate")
+M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 
 -----------------------------------------------------
 ---Checkmate configuration

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -174,7 +174,7 @@ function M.setup_highlights()
 end
 
 ---@class ApplyHighlightingOpts
----@field todo_map table<string, checkmate.TodoItem>? Will use this todo_map instead of running discover_todos
+---@field todo_map table<integer, checkmate.TodoItem>? Will use this todo_map instead of running discover_todos
 ---@field debug_reason string? Reason for call (to help debug why highlighting update was called)
 
 --- TODO: This redraws all highlights and can be expensive for large files.

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -205,7 +205,7 @@ function M.apply_highlighting(bufnr, opts)
   M.clear_line_cache(bufnr)
 
   -- Discover all todo items
-  ---@type table<string, checkmate.TodoItem>
+  ---@type table<integer, checkmate.TodoItem>
   local todo_map = opts.todo_map or parser.discover_todos(bufnr)
 
   -- Process todo items in hierarchical order (top-down)
@@ -230,7 +230,7 @@ end
 ---Process a todo item (and, if requested via `opts.recursive`, its descendants).
 ---@param bufnr integer Buffer number
 ---@param todo_item checkmate.TodoItem The todo item to highlight.
----@param todo_map table<string, checkmate.TodoItem> Todo map from `discover_todos`
+---@param todo_map table<integer, checkmate.TodoItem> Todo map from `discover_todos`
 ---@param opts HighlightTodoOpts? Optional settings.
 ---@return nil
 function M.highlight_todo_item(bufnr, todo_item, todo_map, opts)
@@ -436,14 +436,14 @@ function M.highlight_content(bufnr, todo_item, todo_map)
   -- First line (main content) of the todo item
   local first_row = todo_item.range.start.row
   local line = M.get_buffer_line(bufnr, first_row)
-  local marker_pos = todo_item.todo_marker.position.col
-  local marker_len = #todo_item.todo_marker.text
+  local marker_pos = todo_item.todo_marker.position.col -- byte pos
+  local marker_len = #todo_item.todo_marker.text -- byte length
 
   -- Main content highlight is everything on the first line after the marker
   -- Find content start position (after the marker)
   local main_content_start = line:find("[^%s]", marker_pos + marker_len + 1)
   if main_content_start then
-    main_content_start = main_content_start - 1
+    main_content_start = main_content_start - 1 -- convert to 0-based for extmark
     vim.api.nvim_buf_set_extmark(bufnr, config.ns, first_row, main_content_start, {
       end_row = first_row,
       end_col = #line,
@@ -483,7 +483,7 @@ end
 ---Show todo count indicator
 ---@param bufnr integer Buffer number
 ---@param todo_item checkmate.TodoItem
----@param todo_map table<string, checkmate.TodoItem>
+---@param todo_map table<integer, checkmate.TodoItem>
 function M.show_todo_count_indicator(bufnr, todo_item, todo_map)
   local config = require("checkmate.config")
 

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -200,7 +200,8 @@ function M.apply_highlighting(bufnr, opts)
 
   -- Discover all todo items
   ---@type table<integer, checkmate.TodoItem>
-  local todo_map = opts.todo_map or parser.discover_todos(bufnr)
+  -- local todo_map = opts.todo_map or parser.discover_todos(bufnr)
+  local todo_map = opts.todo_map or parser.get_todo_map(bufnr)
 
   -- Process todo items in hierarchical order (top-down)
   for _, todo_item in pairs(todo_map) do

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -190,6 +190,8 @@ function M._setup_autocommands()
       require("checkmate.config").unregister_buffer(bufnr)
       -- Reset any API state for this buffer
       require("checkmate.api")._debounced_process_buffer_fns[bufnr] = nil
+      -- Clear the todo map cache for this buffer
+      require("checkmate.parser").todo_map_cache[bufnr] = nil
     end,
   })
 

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -248,9 +248,11 @@ function M.toggle(target_state)
 
   local is_visual = util.is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items = api.collect_todo_items_from_selection(is_visual)
+  -- we go ahead a keep the parsed todo_map so that we can initialize the transaction below without it
+  -- also having to discover_todos
+  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
 
-  transaction.run(bufnr, function(_ctx)
+  transaction.run(bufnr, todo_map, function(_ctx)
     for _, item in ipairs(todo_items) do
       _ctx.add_op(api.toggle_state, item.id, target_state)
     end
@@ -281,7 +283,7 @@ function M.set_todo_item(todo_item, target_state)
   end
 
   local bufnr = vim.api.nvim_get_current_buf()
-  transaction.run(bufnr, function(_ctx)
+  transaction.run(bufnr, nil, function(_ctx)
     _ctx.add_op(api.set_todo_item, todo_id, target_state)
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
@@ -337,7 +339,7 @@ function M.add_metadata(metadata_name, value)
 
   local is_visual = util.is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items = api.collect_todo_items_from_selection(is_visual)
+  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -346,7 +348,7 @@ function M.add_metadata(metadata_name, value)
   end
 
   -- Begin a transaction
-  transaction.run(bufnr, function(_ctx)
+  transaction.run(bufnr, todo_map, function(_ctx)
     for _, item in ipairs(todo_items) do
       _ctx.add_op(api.add_metadata, item.id, metadata_name, value)
     end
@@ -379,7 +381,7 @@ function M.remove_metadata(metadata_name)
 
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items = api.collect_todo_items_from_selection(is_visual)
+  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -387,7 +389,7 @@ function M.remove_metadata(metadata_name)
     return
   end
 
-  transaction.run(bufnr, function(_ctx)
+  transaction.run(bufnr, todo_map, function(_ctx)
     for _, item in ipairs(todo_items) do
       _ctx.add_op(api.remove_metadata, item.id, metadata_name)
     end
@@ -418,7 +420,7 @@ function M.remove_all_metadata()
 
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items = api.collect_todo_items_from_selection(is_visual)
+  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -426,7 +428,7 @@ function M.remove_all_metadata()
     return
   end
 
-  transaction.run(bufnr, function(_ctx)
+  transaction.run(bufnr, todo_map, function(_ctx)
     for _, item in ipairs(todo_items) do
       _ctx.add_op(api.remove_all_metadata, item.id)
     end
@@ -464,7 +466,7 @@ function M.toggle_metadata(meta_name, custom_value)
 
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items = api.collect_todo_items_from_selection(is_visual)
+  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -472,7 +474,7 @@ function M.toggle_metadata(meta_name, custom_value)
     return
   end
 
-  transaction.run(bufnr, function(_ctx)
+  transaction.run(bufnr, todo_map, function(_ctx)
     for _, item in ipairs(todo_items) do
       _ctx.add_op(api.toggle_metadata, item.id, meta_name, custom_value)
     end

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -225,21 +225,27 @@ end
 function M.toggle(target_state)
   local api = require("checkmate.api")
   local is_visual = require("checkmate.util").is_visual_mode()
-
-  return api.apply_todo_operation({
-    operation = api.toggle_todo_item,
-    is_visual = is_visual,
-    action_name = "toggle",
-    params = { target_state = target_state },
-  })
+  local bufnr = vim.api.nvim_get_current_buf()
+  local todo_items = api.collect_todo_items_from_selection(is_visual)
+  local hunks = api.compute_toggle_diff(todo_items, target_state)
+  api.apply_diff(bufnr, hunks)
+  require("checkmate.highlights").apply_highlighting(bufnr)
+  return true
 end
 
 ---Sets a given todo item to a specific state
 ---@param todo_item checkmate.TodoItem
 ---@param target_state checkmate.TodoItemState
 function M.set_todo_item(todo_item, target_state)
+  if not todo_item then
+    return
+  end
   local api = require("checkmate.api")
-  return api.toggle_todo_item(todo_item, { target_state = target_state })
+  local bufnr = vim.api.nvim_get_current_buf()
+  local hunks = api.compute_toggle_diff({ todo_item }, target_state)
+  api.apply_diff(bufnr, hunks)
+  require("checkmate.highlights").apply_highlighting(bufnr)
+  return true
 end
 
 --- Set todo item to checked state

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -300,8 +300,10 @@ function M.uncheck()
 end
 
 --- Create a new todo item
+---@returns boolean success
 function M.create()
   require("checkmate.api").create_todo()
+  return true
 end
 
 --- Insert a metadata tag into a todo item at the cursor or per todo in the visual selection

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -350,12 +350,6 @@ function M.add_metadata(metadata_name, value)
     end
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
-
-    -- Handle cursor jump if configured
-    if #todo_items == 1 and meta_props.jump_to_on_insert then
-      local item = todo_items[1]
-      api._handle_metadata_cursor_jump(bufnr, item, metadata_name, meta_props)
-    end
   end)
   return true
 end

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -422,7 +422,7 @@ end
 
 --- Toggle a metadata tag on/off at the cursor or for each todo in the visual selection
 ---@param meta_name string Name of the metadata tag (defined in the config)
----@param custom_value string Value contained in tag
+---@param custom_value string? (Optional) Value contained in tag. If nil, will attempt to get default value from get_value()
 function M.toggle_metadata(meta_name, custom_value)
   local api = require("checkmate.api")
   local profiler = require("checkmate.profiler")
@@ -483,6 +483,7 @@ function M.toggle_metadata(meta_name, custom_value)
     require("checkmate.highlights").apply_highlighting(bufnr)
   end)
   profiler.stop("M.toggle_metadata")
+
   return true
 end
 

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -220,10 +220,11 @@ end
 
 -- PUBLIC API --
 
----Toggle todo item state at cursor or in visual selection
+---Toggle todo item(s) state under cursor or in visual selection
 ---
 ---To set a specific todo item to a target state, use `set_todo_item`
 ---@param target_state? checkmate.TodoItemState Optional target state ("checked" or "unchecked")
+---@return boolean success
 function M.toggle(target_state)
   local api = require("checkmate.api")
   local util = require("checkmate.util")
@@ -268,12 +269,13 @@ end
 ---Sets a given todo item to a specific state
 ---@param todo_item checkmate.TodoItem Todo item to set state
 ---@param target_state checkmate.TodoItemState
+---@return boolean success
 function M.set_todo_item(todo_item, target_state)
   local api = require("checkmate.api")
   local transaction = require("checkmate.transaction")
 
   if not todo_item then
-    return
+    return false
   end
   local todo_id = todo_item.id
 
@@ -294,13 +296,19 @@ function M.set_todo_item(todo_item, target_state)
 end
 
 --- Set todo item to checked state
+---
+--- See `toggle()`
+---@return boolean success
 function M.check()
-  M.toggle("checked")
+  return M.toggle("checked")
 end
 
 --- Set todo item to unchecked state
+---
+--- See `toggle()`
+---@return boolean success
 function M.uncheck()
-  M.toggle("unchecked")
+  return M.toggle("unchecked")
 end
 
 --- Create a new todo item
@@ -310,9 +318,10 @@ function M.create()
   return true
 end
 
---- Insert a metadata tag into a todo item at the cursor or per todo in the visual selection
+--- Insert a metadata tag into a todo item(s) under the cursor or per todo in the visual selection
 ---@param metadata_name string Name of the metadata tag (defined in the config)
 ---@param value string? Value contained in the tag
+---@return boolean success
 function M.add_metadata(metadata_name, value)
   local api = require("checkmate.api")
   local transaction = require("checkmate.transaction")
@@ -322,7 +331,7 @@ function M.add_metadata(metadata_name, value)
   local meta_props = config.options.metadata[metadata_name]
   if not meta_props then
     util.notify("Unknown metadata tag: " .. metadata_name, vim.log.levels.WARN)
-    return
+    return false
   end
 
   local ctx = transaction.current_context()
@@ -346,7 +355,7 @@ function M.add_metadata(metadata_name, value)
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
     util.notify(string.format("No todo items found at %s", mode_msg), vim.log.levels.INFO)
-    return
+    return false
   end
 
   -- Begin a transaction
@@ -362,6 +371,7 @@ end
 
 --- Remove a metadata tag from a todo item at the cursor or per todo in the visual selection
 ---@param metadata_name string Name of the metadata tag (defined in the config)
+---@return boolean success
 function M.remove_metadata(metadata_name)
   local api = require("checkmate.api")
   local util = require("checkmate.util")
@@ -388,7 +398,7 @@ function M.remove_metadata(metadata_name)
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
     util.notify(string.format("No todo items found at %s", mode_msg), vim.log.levels.INFO)
-    return
+    return false
   end
 
   transaction.run(bufnr, todo_map, function(_ctx)
@@ -401,6 +411,8 @@ function M.remove_metadata(metadata_name)
   return true
 end
 
+---Removes all metadata from a todo item(s) under the cursor or include in visual selection
+---@return boolean success
 function M.remove_all_metadata()
   local api = require("checkmate.api")
   local util = require("checkmate.util")
@@ -427,7 +439,7 @@ function M.remove_all_metadata()
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
     util.notify(string.format("No todo items found at %s", mode_msg), vim.log.levels.INFO)
-    return
+    return false
   end
 
   transaction.run(bufnr, todo_map, function(_ctx)
@@ -440,9 +452,10 @@ function M.remove_all_metadata()
   return true
 end
 
---- Toggle a metadata tag on/off at the cursor or for each todo in the visual selection
+--- Toggle a metadata tag on/off for todo item under the cursor or for each todo in the visual selection
 ---@param meta_name string Name of the metadata tag (defined in the config)
 ---@param custom_value string? (Optional) Value contained in tag. If nil, will attempt to get default value from get_value()
+---@return boolean success
 function M.toggle_metadata(meta_name, custom_value)
   local api = require("checkmate.api")
   local transaction = require("checkmate.transaction")
@@ -473,7 +486,7 @@ function M.toggle_metadata(meta_name, custom_value)
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
     util.notify(string.format("No todo items found at %s", mode_msg), vim.log.levels.INFO)
-    return
+    return false
   end
 
   transaction.run(bufnr, todo_map, function(_ctx)

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -230,11 +230,14 @@ function M.toggle(target_state)
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
   local todo_items = api.collect_todo_items_from_selection(is_visual)
-  local hunks = api.compute_diff_toggle(todo_items, target_state)
-  api.apply_diff(bufnr, hunks)
-  require("checkmate.highlights").apply_highlighting(bufnr)
 
-  profiler.stop("M.toggle")
+  api.with_bulk_context(bufnr, todo_items, function(items)
+    local hunks = api.compute_diff_toggle(items, target_state)
+    api.apply_diff(bufnr, hunks)
+  end, function()
+    require("checkmate.highlights").apply_highlighting(bufnr)
+    profiler.stop("M.toggle")
+  end)
   return true
 end
 
@@ -246,10 +249,22 @@ function M.set_todo_item(todo_item, target_state)
     return
   end
   local api = require("checkmate.api")
+
   local bufnr = vim.api.nvim_get_current_buf()
-  local hunks = api.compute_diff_toggle({ todo_item }, target_state)
-  api.apply_diff(bufnr, hunks)
-  require("checkmate.highlights").apply_highlighting(bufnr)
+  api.with_bulk_context(bufnr, { todo_item }, function(items)
+    if api._bulk_context.active then
+      api._queue_bulk_change({
+        type = "toggle_state",
+        todo_item = todo_item,
+        target_state = target_state,
+      })
+    else
+      local hunks = api.compute_diff_toggle(items, target_state)
+      api.apply_diff(bufnr, hunks)
+    end
+  end, function()
+    require("checkmate.highlights").apply_highlighting(bufnr)
+  end)
   return true
 end
 
@@ -292,6 +307,13 @@ function M.add_metadata(metadata_name, value)
     return
   end
 
+  -- Start bulk operation if multiple items
+  local is_bulk = #todo_items > 1
+  if is_bulk then
+    api._start_bulk_operation()
+  end
+
+  -- Apply main operation
   local hunks = api.compute_diff_add_metadata(todo_items, metadata_name, value)
   api.apply_diff(bufnr, hunks)
 
@@ -305,6 +327,14 @@ function M.add_metadata(metadata_name, value)
     -- Handle cursor jump/selection if this is the only item
     if #todo_items == 1 and meta_props.jump_to_on_insert then
       api._handle_metadata_cursor_jump(bufnr, todo_item, metadata_name, meta_props)
+    end
+  end
+
+  -- End bulk operation and apply any queued changes
+  if is_bulk then
+    local bulk_hunks = api._end_bulk_operation(bufnr)
+    if #bulk_hunks > 0 then
+      api.apply_diff(bufnr, bulk_hunks)
     end
   end
 
@@ -334,6 +364,13 @@ function M.remove_metadata(metadata_name)
     end
   end
 
+  -- Start bulk operation if multiple items
+  local is_bulk = #todo_items > 1
+  if is_bulk then
+    api._start_bulk_operation()
+  end
+
+  -- Apply main operation
   local hunks = api.compute_diff_remove_metadata(todo_items, metadata_name)
   api.apply_diff(bufnr, hunks)
 
@@ -344,6 +381,14 @@ function M.remove_metadata(metadata_name)
     local meta_config = config.options.metadata[entry.tag] or config.options.metadata[entry.alias_for] or {}
     if meta_config.on_remove then
       meta_config.on_remove(item)
+    end
+  end
+
+  -- End bulk operation and apply any queued changes
+  if is_bulk then
+    local bulk_hunks = api._end_bulk_operation(bufnr)
+    if #bulk_hunks > 0 then
+      api.apply_diff(bufnr, bulk_hunks)
     end
   end
 
@@ -382,12 +427,27 @@ function M.remove_all_metadata()
     end
   end
 
+  -- Start bulk operation if multiple items
+  local is_bulk = #todo_items > 1
+  if is_bulk then
+    api._start_bulk_operation()
+  end
+
+  -- Apply main operation
   local hunks = api.compute_diff_remove_all_metadata(todo_items)
   api.apply_diff(bufnr, hunks)
 
   -- Run callbacks
   for _, callback_info in ipairs(callbacks_to_run) do
     callback_info.func(callback_info.item)
+  end
+
+  -- End bulk operation and apply any queued changes
+  if is_bulk then
+    local bulk_hunks = api._end_bulk_operation(bufnr)
+    if #bulk_hunks > 0 then
+      api.apply_diff(bufnr, bulk_hunks)
+    end
   end
 
   require("checkmate.highlights").apply_highlighting(bufnr, { debug_reason = "remove_all_metadata" })
@@ -423,6 +483,13 @@ function M.toggle_metadata(meta_name, custom_value)
     end
   end
 
+  -- Start bulk operation if multiple items
+  local is_bulk = #todo_items > 1
+  if is_bulk then
+    api._start_bulk_operation()
+  end
+
+  -- Apply main operation
   local hunks = api.compute_diff_toggle_metadata(todo_items, meta_name, custom_value)
   api.apply_diff(bufnr, hunks)
 
@@ -448,6 +515,14 @@ function M.toggle_metadata(meta_name, custom_value)
     -- Handle cursor jump for single item toggle
     if #todo_items == 1 and #items_adding == 1 and meta_config.jump_to_on_insert then
       api._handle_metadata_cursor_jump(bufnr, items_adding[1], meta_name, meta_config)
+    end
+  end
+
+  -- End bulk operation and apply any queued changes
+  if is_bulk then
+    local bulk_hunks = api._end_bulk_operation(bufnr)
+    if #bulk_hunks > 0 then
+      api.apply_diff(bufnr, bulk_hunks)
     end
   end
 

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -71,7 +71,7 @@ local PATTERN_CACHE = {
   unchecked_todo = nil,
 }
 
-local function clear_pattern_cache()
+function M.clear_pattern_cache()
   PATTERN_CACHE = {
     checked_todo = nil,
     unchecked_todo = nil,
@@ -116,6 +116,7 @@ M.todo_map_cache = {}
 ---@return table<integer, checkmate.TodoItem>
 function M.get_todo_map(bufnr)
   if not vim.api.nvim_buf_is_valid(bufnr) then
+    vim.notify("Checkmate: Invalid buffer", vim.log.levels.ERROR)
     return {}
   end
 
@@ -168,7 +169,7 @@ function M.setup()
   local log = require("checkmate.log")
 
   -- Clear pattern cache in case config changed
-  clear_pattern_cache()
+  M.clear_pattern_cache()
 
   -- Clear todo map cache
   M.todo_map_cache = {}
@@ -506,6 +507,7 @@ function M.discover_todos(bufnr)
   local tree = parser:parse()[1]
   if not tree then
     log.debug("Failed to parse buffer", { module = "parser" })
+    vim.notify("Checkmate: Failed to parse buffer", vim.log.levels.ERROR)
     return todo_map
   end
 
@@ -661,16 +663,7 @@ end
 ---Returns a TS query for finding markdown list_markers
 ---@return vim.treesitter.Query
 function M.get_list_marker_query()
-  return vim.treesitter.query.parse(
-    "markdown",
-    [[
-    (list_marker_minus) @list_marker_minus
-    (list_marker_plus) @list_marker_plus
-    (list_marker_star) @list_marker_star
-    (list_marker_dot) @list_marker_ordered
-    (list_marker_parenthesis) @list_marker_ordered
-    ]]
-  )
+  return FULL_TODO_QUERY
 end
 
 ---Returns the list_marker type as "unordered" or "ordered"

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -45,7 +45,7 @@ local M = {}
 --- @field todo_marker TodoMarkerInfo Information about the todo marker (0-indexed position)
 --- @field list_marker ListMarkerInfo Information about the list marker (0-indexed position)
 --- @field metadata checkmate.TodoMetadata | {} Metadata for this todo item
---- @field todo_text string Text content of the todo item line (first line), may be truncated. Only for debugging.
+--- @field todo_text string Text content of the todo item line (first line), may be truncated. Only for debugging or tests.
 --- @field children integer[] IDs of child todo items
 --- @field parent_id integer? ID of parent todo item
 

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -94,15 +94,21 @@ end
 -- [buffer] -> {version: integer, current: table<integer, checkmate.TodoItem> }
 M.todo_map_cache = {}
 
+---Returns a todo map of the current buffer
+---Will hit cache if buffer has not changed since last full parse,
+---according to :changedtick
+---@param bufnr integer Buffer number
+---@return table<integer, checkmate.TodoItem>
 function M.get_todo_map(bufnr)
   if not vim.api.nvim_buf_is_valid(bufnr) then
     return {}
   end
 
   local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+  local cache = M.todo_map_cache[bufnr]
 
-  if M.todo_map_cache[bufnr] and changedtick == M.todo_map_cache[bufnr].version then
-    return M.todo_map_cache[bufnr].current -- todo map
+  if cache and changedtick == cache.version then
+    return cache.current -- todo map
   end
 
   local fresh_todo_map = M.discover_todos(bufnr)

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -32,15 +32,16 @@ end
 
 --- Starts a transaction for a buffer
 ---@param bufnr number Buffer number
+---@param todo_map table<integer, checkmate.TodoItem>? Optional todo_map to initialize state. Only pass if guaranteed fresh.
 ---@param entry_fn function Function to start the transaction
 ---@param post_fn function? Function to run after transaction completes
-function M.run(bufnr, entry_fn, post_fn)
+function M.run(bufnr, todo_map, entry_fn, post_fn)
   assert(not M._state, "Nested transactions are not supported")
 
   -- Initialize transaction state
   local state = {
     bufnr = bufnr,
-    todo_map = parser.discover_todos(bufnr),
+    todo_map = todo_map or parser.discover_todos(bufnr),
     op_queue = {},
     cb_queue = {},
     seen_ops = {},

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -1,0 +1,150 @@
+-- checkmate/transaction.lua
+
+local M = {}
+local parser = require("checkmate.parser")
+local api = require("checkmate.api")
+
+M._state = nil
+
+-- Helper: Group operations by their API function
+local function group_by_fn(ops)
+  local batches = {}
+  for _, op in ipairs(ops) do
+    local fn = op.fn
+    batches[fn] = batches[fn] or {}
+    table.insert(batches[fn], op)
+  end
+  return batches
+end
+
+function M.is_active()
+  return M._state ~= nil
+end
+
+function M.current_context()
+  return M._state and M._state.context or nil
+end
+
+--- Get current transaction state (for debugging)
+function M.get_state()
+  return M._state
+end
+
+--- Starts a transaction for a buffer
+---@param bufnr number Buffer number
+---@param entry_fn function Function to start the transaction
+---@param post_fn function Function to run after transaction completes
+function M.run(bufnr, entry_fn, post_fn)
+  assert(not M._state, "Nested transactions are not supported")
+
+  -- Initialize transaction state
+  local state = {
+    bufnr = bufnr,
+    todo_map = parser.discover_todos(bufnr),
+    op_queue = {},
+    cb_queue = {},
+    seen_ops = {},
+  }
+
+  -- Create the transaction context
+  state.context = {
+    -- Get the current (latest) todo item by ID
+    get_item = function(extmark_id)
+      local item = M._state.todo_map[extmark_id]
+      if not item then
+        vim.notify("Could not find extmark_id: " .. extmark_id)
+        vim.notify(vim.inspect(vim.api.nvim_buf_get_extmarks(0, require("checkmate.config").ns_todos, 0, -1, {})))
+      end
+      return M._state.todo_map[extmark_id]
+    end,
+
+    -- Queue an API operation
+    add_op = function(fn, extmark_id, ...)
+      local fn_name = debug.getinfo(fn, "n").name or tostring(fn)
+      local key = fn_name .. ":" .. tostring(extmark_id)
+      if not M._state.seen_ops[key] then
+        M._state.seen_ops[key] = true
+        table.insert(M._state.op_queue, {
+          fn = fn,
+          extmark_id = extmark_id,
+          params = { ... },
+        })
+      end
+    end,
+
+    -- Queue a callback
+    add_cb = function(cb_fn, ...)
+      table.insert(M._state.cb_queue, {
+        cb_fn = cb_fn,
+        params = { ... },
+      })
+    end,
+
+    bufnr = bufnr,
+  }
+
+  M._state = state
+
+  -- Execute the entry function
+  entry_fn(state.context)
+
+  -- Transaction loop: process operations and callbacks until both queues are empty
+  while #M._state.op_queue > 0 or #M._state.cb_queue > 0 do
+    -- Process all queued operations
+    if #M._state.op_queue > 0 then
+      local ops = M._state.op_queue
+      M._state.op_queue = {}
+
+      -- Group operations by function for batch processing
+      local grouped = group_by_fn(ops)
+
+      for fn, fn_ops in pairs(grouped) do
+        -- Prepare items and params arrays for the API function
+        local items = {}
+        local params = {}
+
+        for _, op in ipairs(fn_ops) do
+          -- Find the item using the string ID
+          local item = M._state.todo_map[op.extmark_id]
+          if item then
+            table.insert(items, item)
+            table.insert(params, op.params)
+          end
+        end
+
+        if #items > 0 then
+          -- Call the API function with proper signature
+          local hunks = fn(items, params, state.context)
+
+          -- Apply the diff if we got hunks back
+          if hunks and #hunks > 0 then
+            api.apply_diff(bufnr, hunks)
+            -- Refresh the todo map after buffer changes
+            M._state.todo_map = parser.discover_todos(bufnr)
+          end
+        end
+      end
+    end
+
+    -- Process all queued callbacks
+    if #M._state.cb_queue > 0 then
+      local cbs = M._state.cb_queue
+      M._state.cb_queue = {}
+
+      for _, cb in ipairs(cbs) do
+        -- Execute callback with transaction context
+        cb.cb_fn(state.context, unpack(cb.params))
+      end
+    end
+  end
+
+  -- Execute post-transaction function
+  if post_fn then
+    post_fn()
+  end
+
+  -- Clear transaction state
+  M._state = nil
+end
+
+return M

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -41,7 +41,7 @@ function M.run(bufnr, todo_map, entry_fn, post_fn)
   -- Initialize transaction state
   local state = {
     bufnr = bufnr,
-    todo_map = todo_map or parser.discover_todos(bufnr),
+    todo_map = todo_map or parser.get_todo_map(bufnr),
     op_queue = {},
     cb_queue = {},
     seen_ops = {},

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -33,7 +33,7 @@ end
 --- Starts a transaction for a buffer
 ---@param bufnr number Buffer number
 ---@param entry_fn function Function to start the transaction
----@param post_fn function Function to run after transaction completes
+---@param post_fn function? Function to run after transaction completes
 function M.run(bufnr, entry_fn, post_fn)
   assert(not M._state, "Nested transactions are not supported")
 

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -290,9 +290,9 @@ function M.build_markdown_checkbox_patterns(list_item_markers, checkbox_pattern)
 end
 
 ---Returns a todo_map table sorted by start row
----@generic T: table<string, checkmate.TodoItem>
+---@generic T: table<integer, checkmate.TodoItem>
 ---@param todo_map T
----@return table<string, checkmate.TodoItem>
+---@return table<integer, checkmate.TodoItem>
 function M.get_sorted_todo_list(todo_map)
   -- Convert map to array of {id, item} pairs
   local todo_list = {}
@@ -417,6 +417,22 @@ function M.get_heading_string(title, level)
   level = tonumber(level) or 2
   level = math.min(math.max(level, 1), 6)
   return string.rep("#", level) .. " " .. title
+end
+
+---Returns the lines that encompass the given buffer rows
+---@param bufnr integer Buffer number
+---@param rows integer[] Rows that should be included
+---@return string[] lines String array of lines from the buffer that include the min and max row
+function M.get_buffer_lines(bufnr, rows)
+  local min_row = math.min(unpack(rows))
+  local max_row = math.max(unpack(rows))
+  local bulk_lines = vim.api.nvim_buf_get_lines(bufnr, min_row, max_row + 1, false)
+
+  local lines = {}
+  for _, row in ipairs(rows) do
+    lines[row] = bulk_lines[row - min_row + 1]
+  end
+  return lines
 end
 
 -- Cursor helper

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -292,7 +292,7 @@ end
 ---Returns a todo_map table sorted by start row
 ---@generic T: table<integer, checkmate.TodoItem>
 ---@param todo_map T
----@return table<integer, checkmate.TodoItem>
+---@return {id: integer, item: checkmate.TodoItem}
 function M.get_sorted_todo_list(todo_map)
   -- Convert map to array of {id, item} pairs
   local todo_list = {}

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -208,9 +208,9 @@ function M.build_todo_patterns(opts)
     with_capture = false,
   })
 
-  --- Build multiple full-patterns from todo_marker
-  -- @param todo_marker string: The todo marker to look for
-  -- @return string[]: List of full Lua patterns to match
+  ---Build multiple full-patterns from todo_marker
+  ---@param todo_marker string: The todo marker to look for
+  ---@return string[] patterns List of full Lua patterns to match
   local function build_patterns_with_marker(todo_marker)
     local escaped_todo = escape_literal(todo_marker)
     local patterns = {}
@@ -468,22 +468,6 @@ function M.batch_get_lines(bufnr, rows)
   read_range()
 
   return result
-end
-
----Returns the lines that encompass the given buffer rows
----@param bufnr integer Buffer number
----@param rows integer[] Rows that should be included
----@return string[] lines String array of lines from the buffer that include the min and max row
-function M.get_buffer_lines(bufnr, rows)
-  local min_row = math.min(unpack(rows))
-  local max_row = math.max(unpack(rows))
-  local bulk_lines = vim.api.nvim_buf_get_lines(bufnr, min_row, max_row + 1, false)
-
-  local lines = {}
-  for _, row in ipairs(rows) do
-    lines[row] = bulk_lines[row - min_row + 1]
-  end
-  return lines
 end
 
 --- Simple line cache for operations that need repeated access to same lines

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -200,9 +200,7 @@ describe("API", function()
       end
 
       -- Toggle task 2 to checked
-      local success = require("checkmate").set_todo_item(task_2, "checked")
-
-      assert.is_true(success)
+      require("checkmate").set_todo_item(task_2, "checked")
 
       -- Save the file
       vim.cmd("write")

--- a/tests/checkmate/parser_spec.lua
+++ b/tests/checkmate/parser_spec.lua
@@ -295,7 +295,7 @@ describe("Parser", function()
       local level5_todo = find_todo_by_text(todo_map, "Level 5 todo")
       assert.is_not_nil(level5_todo)
       ---@cast level5_todo checkmate.TodoItem
-      assert.equal(level4_todo.node:id(), level5_todo.parent_id)
+      assert.equal(level4_todo.id, level5_todo.parent_id)
       -- verify expected TS nodes above it
       assert.equal("list_item", level5_todo.node:parent():parent():type())
       assert.equal("list", level5_todo.node:parent():type())
@@ -313,14 +313,14 @@ describe("Parser", function()
       assert.is_not_nil(another_level2)
       ---@cast another_level2 checkmate.TodoItem
 
-      assert.equal(level1_todo.node:id(), tab_indent.parent_id)
-      assert.equal(tab_indent.node:id(), double_tab.parent_id)
+      assert.equal(level1_todo.id, tab_indent.parent_id)
+      assert.equal(tab_indent.id, double_tab.parent_id)
 
       -- Verify unusual hierarchy jump (top level to level 3)
       local unusual = find_todo_by_text(todo_map, "Direct jump to Level 3")
       assert.is_not_nil(unusual)
       ---@cast unusual checkmate.TodoItem
-      assert.equal(another_top.node:id(), unusual.parent_id)
+      assert.equal(another_top.id, unusual.parent_id)
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
@@ -372,14 +372,10 @@ describe("Parser", function()
       assert.equal(2, #ordered_parent.children)
 
       -- Verify mixed list marker relationships
-      assert.equal(
-        parent_dash.node:id(),
-        child_asterisk.parent_id,
-        "Child with asterisk should be child of parent with dash"
-      )
-      assert.equal(parent_dash.node:id(), child_plus.parent_id)
-      assert.equal(ordered_parent.node:id(), ordered_child.parent_id, "Ordered child should be child of ordered parent")
-      assert.equal(ordered_parent.node:id(), mixed_child.parent_id, "Unordered child should be child of ordered parent")
+      assert.equal(parent_dash.id, child_asterisk.parent_id, "Child with asterisk should be child of parent with dash")
+      assert.equal(parent_dash.id, child_plus.parent_id)
+      assert.equal(ordered_parent.id, ordered_child.parent_id, "Ordered child should be child of ordered parent")
+      assert.equal(ordered_parent.id, mixed_child.parent_id, "Unordered child should be child of ordered parent")
 
       -- Verify list marker type is correctly detected
       assert.equal("unordered", parent_dash.list_marker.type)
@@ -435,8 +431,8 @@ Line that should not affect parent-child relationship
 
       -- Verify parent-child with content in between
       assert.equal(2, #parent_todo.children)
-      assert.equal(parent_todo.node:id(), checked_child.parent_id)
-      assert.equal(parent_todo.node:id(), unchecked_child.parent_id)
+      assert.equal(parent_todo.id, checked_child.parent_id)
+      assert.equal(parent_todo.id, unchecked_child.parent_id)
 
       -- Verify checked state is maintained in hierarchy
       assert.equal("unchecked", parent_todo.state)
@@ -999,7 +995,7 @@ Line that should not affect parent-child relationship
       local child = todo_map[child_id]
 
       assert.is_not_nil(child)
-      assert.equal(section3_todo2.node:id(), child.parent_id)
+      assert.equal(section3_todo2.id, child.parent_id)
 
       -- Spot check some selected todos to ensure they all have valid ranges
       local count = 0

--- a/tests/checkmate/parser_spec.lua
+++ b/tests/checkmate/parser_spec.lua
@@ -17,16 +17,6 @@ describe("Parser", function()
     _G.reset_state()
   end)
 
-  -- Helper to find a specific todo in the todo_map by pattern matching on the todo text
-  local function find_todo_by_text(todo_map, pattern)
-    for _, todo in pairs(todo_map) do
-      if todo.todo_text:match(pattern) then
-        return todo
-      end
-    end
-    return nil
-  end
-
   -- Helper to verify todo range is consistent with its content
   local function verify_todo_range_matches_content(bufnr, todo)
     -- End row should not exceed buffer line count
@@ -170,9 +160,9 @@ describe("Parser", function()
       local todo_map = parser.discover_todos(bufnr)
 
       -- Find our test todos by text pattern
-      local single_line = find_todo_by_text(todo_map, "Single line")
-      local multi_line = find_todo_by_text(todo_map, "Multi%-line")
-      local three_line = find_todo_by_text(todo_map, "Three line")
+      local single_line = h.find_todo_by_text(todo_map, "Single line")
+      local multi_line = h.find_todo_by_text(todo_map, "Multi%-line")
+      local three_line = h.find_todo_by_text(todo_map, "Three line")
 
       assert.is_not_nil(single_line)
       ---@cast single_line checkmate.TodoItem
@@ -235,10 +225,10 @@ describe("Parser", function()
       assert.equal(12, total_todos)
 
       -- Find top-level todos
-      local level1_todo = find_todo_by_text(todo_map, "Level 1 todo")
-      local another_top = find_todo_by_text(todo_map, "Another top%-level todo")
-      local empty_content = find_todo_by_text(todo_map, "Todo with empty content")
-      local empty_line = find_todo_by_text(todo_map, "- " .. unchecked .. " %s*$") -- Empty line after marker
+      local level1_todo = h.find_todo_by_text(todo_map, "Level 1 todo")
+      local another_top = h.find_todo_by_text(todo_map, "Another top%-level todo")
+      local empty_content = h.find_todo_by_text(todo_map, "Todo with empty content")
+      local empty_line = h.find_todo_by_text(todo_map, "- " .. unchecked .. " %s*$") -- Empty line after marker
 
       assert.is_not_nil(level1_todo)
       ---@cast level1_todo checkmate.TodoItem
@@ -292,7 +282,7 @@ describe("Parser", function()
       assert.equal(1, #level4_todo.children)
 
       -- Verify deep nesting to level 5
-      local level5_todo = find_todo_by_text(todo_map, "Level 5 todo")
+      local level5_todo = h.find_todo_by_text(todo_map, "Level 5 todo")
       assert.is_not_nil(level5_todo)
       ---@cast level5_todo checkmate.TodoItem
       assert.equal(level4_todo.id, level5_todo.parent_id)
@@ -301,15 +291,15 @@ describe("Parser", function()
       assert.equal("list", level5_todo.node:parent():type())
 
       -- Verify tab indentation is handled properly
-      local tab_indent = find_todo_by_text(todo_map, "Tab indentation")
-      local double_tab = find_todo_by_text(todo_map, "Double tab indentation")
+      local tab_indent = h.find_todo_by_text(todo_map, "Tab indentation")
+      local double_tab = h.find_todo_by_text(todo_map, "Double tab indentation")
       assert.is_not_nil(tab_indent)
       ---@cast tab_indent checkmate.TodoItem
       assert.is_not_nil(double_tab)
       ---@cast double_tab checkmate.TodoItem
 
       -- Tab indented item should be child of Another Level 2
-      local another_level2 = find_todo_by_text(todo_map, "Another Level 2")
+      local another_level2 = h.find_todo_by_text(todo_map, "Another Level 2")
       assert.is_not_nil(another_level2)
       ---@cast another_level2 checkmate.TodoItem
 
@@ -317,7 +307,7 @@ describe("Parser", function()
       assert.equal(tab_indent.id, double_tab.parent_id)
 
       -- Verify unusual hierarchy jump (top level to level 3)
-      local unusual = find_todo_by_text(todo_map, "Direct jump to Level 3")
+      local unusual = h.find_todo_by_text(todo_map, "Direct jump to Level 3")
       assert.is_not_nil(unusual)
       ---@cast unusual checkmate.TodoItem
       assert.equal(another_top.id, unusual.parent_id)
@@ -347,12 +337,12 @@ describe("Parser", function()
       local todo_map = parser.discover_todos(bufnr)
 
       -- Find todos with different list types
-      local parent_dash = find_todo_by_text(todo_map, "Parent with dash")
-      local child_asterisk = find_todo_by_text(todo_map, "Child with asterisk")
-      local child_plus = find_todo_by_text(todo_map, "Child with plus")
-      local ordered_parent = find_todo_by_text(todo_map, "Ordered parent")
-      local ordered_child = find_todo_by_text(todo_map, "Ordered child")
-      local mixed_child = find_todo_by_text(todo_map, "Unordered child with asterisk")
+      local parent_dash = h.find_todo_by_text(todo_map, "Parent with dash")
+      local child_asterisk = h.find_todo_by_text(todo_map, "Child with asterisk")
+      local child_plus = h.find_todo_by_text(todo_map, "Child with plus")
+      local ordered_parent = h.find_todo_by_text(todo_map, "Ordered parent")
+      local ordered_child = h.find_todo_by_text(todo_map, "Ordered child")
+      local mixed_child = h.find_todo_by_text(todo_map, "Unordered child with asterisk")
 
       assert.is_not_nil(parent_dash)
       ---@cast parent_dash checkmate.TodoItem
@@ -408,11 +398,11 @@ Line that should not affect parent-child relationship
       local todo_map = parser.discover_todos(bufnr)
 
       -- Find todos in edge positions
-      local start_todo = find_todo_by_text(todo_map, "Todo at document start")
-      local parent_todo = find_todo_by_text(todo_map, "Parent todo")
-      local checked_child = find_todo_by_text(todo_map, "Checked child")
-      local unchecked_child = find_todo_by_text(todo_map, "Unchecked child")
-      local end_todo = find_todo_by_text(todo_map, "Todo at document end")
+      local start_todo = h.find_todo_by_text(todo_map, "Todo at document start")
+      local parent_todo = h.find_todo_by_text(todo_map, "Parent todo")
+      local checked_child = h.find_todo_by_text(todo_map, "Checked child")
+      local unchecked_child = h.find_todo_by_text(todo_map, "Unchecked child")
+      local end_todo = h.find_todo_by_text(todo_map, "Todo at document end")
 
       assert.is_not_nil(start_todo)
       ---@cast start_todo checkmate.TodoItem
@@ -440,6 +430,39 @@ Line that should not affect parent-child relationship
       assert.equal("unchecked", unchecked_child.state)
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("should return correct buffer positions for each discovered todo item", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.options.todo_markers.checked
+
+      -- Prepare a buffer with two todos, one unchecked and one checked
+      local file_path = h.create_temp_file()
+      local content = [[
+- ]] .. unchecked .. [[ Alpha
+- ]] .. checked .. [[ Beta
+]]
+      local bufnr = h.create_test_buffer(content)
+
+      -- Discover todos in the buffer
+      local todo_map = parser.discover_todos(bufnr)
+      assert.equal(2, vim.tbl_count(todo_map))
+
+      -- For each todo, get its recorded position and compare
+      for _, todo in pairs(todo_map) do
+        local pos = parser.get_todo_position(bufnr, todo.id)
+        assert.is_not_nil(pos)
+        ---@cast pos {row: integer, col: integer}
+        -- should match the marker's stored position
+        assert.equal(todo.todo_marker.position.row, pos.row)
+        assert.equal(todo.todo_marker.position.col, pos.col)
+      end
+
+      finally(function()
+        h.cleanup_buffer(bufnr, file_path)
+      end)
     end)
   end)
 

--- a/tests/checkmate/transaction_spec.lua
+++ b/tests/checkmate/transaction_spec.lua
@@ -23,7 +23,7 @@ describe("Transaction", function()
     assert.is_false(transaction.is_active())
 
     -- Run a transaction that toggles TaskX to 'checked'
-    transaction.run(bufnr, function(ctx)
+    transaction.run(bufnr, nil, function(ctx)
       local todo_map = parser.discover_todos(bufnr)
       local todo = h.find_todo_by_text(todo_map, "TaskX")
       assert.is_not_nil(todo)
@@ -50,7 +50,7 @@ describe("Transaction", function()
     local received = nil
 
     -- Run a transaction that only queues a callback
-    require("checkmate.transaction").run(bufnr, function(ctx)
+    require("checkmate.transaction").run(bufnr, nil, function(ctx)
       ctx.add_cb(function(_, val)
         called = true
         received = val

--- a/tests/checkmate/transaction_spec.lua
+++ b/tests/checkmate/transaction_spec.lua
@@ -1,0 +1,67 @@
+describe("Transaction", function()
+  local h = require("tests.checkmate.helpers")
+
+  before_each(function()
+    _G.reset_state()
+
+    h.ensure_normal_mode()
+  end)
+
+  it("should apply queued operations and clear state", function()
+    local config = require("checkmate.config")
+    local transaction = require("checkmate.transaction")
+    local parser = require("checkmate.parser")
+    local api = require("checkmate.api")
+
+    local unchecked = config.options.todo_markers.unchecked
+    local checked = config.options.todo_markers.checked
+
+    -- Create temp buf with one unchecked todo
+    local content = "- " .. unchecked .. " TaskX"
+    local bufnr = h.create_test_buffer(content)
+
+    assert.is_false(transaction.is_active())
+
+    -- Run a transaction that toggles TaskX to 'checked'
+    transaction.run(bufnr, function(ctx)
+      local todo_map = parser.discover_todos(bufnr)
+      local todo = h.find_todo_by_text(todo_map, "TaskX")
+      assert.is_not_nil(todo)
+      ---@cast todo checkmate.TodoItem
+      ctx.add_op(api.toggle_state, todo.id, "checked")
+    end, function()
+      -- Post-transaction: buffer line should now show checked marker
+      local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+      assert.matches(checked, line)
+    end)
+
+    assert.is_false(transaction.is_active())
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+
+  it("should execute queued callbacks within a transaction", function()
+    -- empty buffer (no todo items needed for callback test)
+    local bufnr = h.create_test_buffer("")
+
+    local called = false
+    local received = nil
+
+    -- Run a transaction that only queues a callback
+    require("checkmate.transaction").run(bufnr, function(ctx)
+      ctx.add_cb(function(_, val)
+        called = true
+        received = val
+      end, 123)
+    end)
+
+    assert.is_true(called)
+    assert.equal(123, received)
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+end)

--- a/tests/checkmate/util_spec.lua
+++ b/tests/checkmate/util_spec.lua
@@ -1,0 +1,274 @@
+describe("Util", function()
+  local util = require("checkmate.util")
+
+  --[[ describe("debugging char_to_byte_col", function()
+    it("should show what vim.str_byteindex actually returns", function()
+      local line = "- □ Test"
+
+      print("\nDebugging line: '" .. line .. "'")
+      print("Line byte length: " .. #line)
+
+      -- Let's check each character position
+      for char_pos = 0, 8 do
+        local ok, byte_idx = pcall(vim.str_byteindex, line, "utf-8", char_pos)
+        if ok then
+          print(string.format("char_pos=%d -> byte_idx=%d", char_pos, byte_idx))
+        else
+          print(string.format("char_pos=%d -> ERROR: %s", char_pos, tostring(byte_idx)))
+        end
+      end
+
+      -- Let's also check what each byte contains
+      print("\nByte-by-byte breakdown:")
+      for i = 1, #line do
+        local byte = line:byte(i)
+        print(
+          string.format(
+            "byte[%d] = %d (0x%02X) = '%s'",
+            i - 1,
+            byte,
+            byte,
+            byte >= 32 and byte <= 126 and string.char(byte) or "?"
+          )
+        )
+      end
+
+      -- Check UTF-8 encoding of □
+      local box = "□"
+      print("\nUTF-8 encoding of '□':")
+      for i = 1, #box do
+        print(string.format("  byte[%d] = %d (0x%02X)", i, box:byte(i), box:byte(i)))
+      end
+    end)
+
+    it("should verify our understanding of vim.str_byteindex", function()
+      -- Test with simple ASCII
+      local ascii_line = "hello"
+      assert.equal(0, vim.str_byteindex(ascii_line, "utf-8", 0))
+      assert.equal(1, vim.str_byteindex(ascii_line, "utf-8", 1))
+      assert.equal(2, vim.str_byteindex(ascii_line, "utf-8", 2))
+
+      -- Test with Unicode
+      local unicode_line = "a□b" -- 'a' at byte 0, '□' at bytes 1-3, 'b' at byte 4
+      print("\nTesting line: 'a□b'")
+      print("Total bytes: " .. #unicode_line)
+
+      -- Character positions vs byte positions:
+      -- char 0 ('a') -> byte 0
+      -- char 1 ('□') -> byte 1
+      -- char 2 ('b') -> byte 4
+
+      local result0 = vim.str_byteindex(unicode_line, "utf-8", 0)
+      local result1 = vim.str_byteindex(unicode_line, "utf-8", 1)
+      local result2 = vim.str_byteindex(unicode_line, "utf-8", 2)
+
+      print(string.format("char 0 -> byte %d (expected 0)", result0))
+      print(string.format("char 1 -> byte %d (expected 1)", result1))
+      print(string.format("char 2 -> byte %d (expected 4)", result2))
+
+      assert.equal(0, result0)
+      assert.equal(1, result1)
+      assert.equal(4, result2)
+    end)
+
+    it("should test the actual util.char_to_byte_col function", function()
+      local line = "- □ Test"
+
+      -- Let's trace through what happens
+      print("\nTracing util.char_to_byte_col for: '" .. line .. "'")
+
+      -- Test each position
+      local positions = {
+        { char = 0, expected_byte = 0, desc = "start of line" },
+        { char = 1, expected_byte = 1, desc = "'-' to ' '" },
+        { char = 2, expected_byte = 2, desc = "' ' to '□'" },
+        { char = 3, expected_byte = 5, desc = "'□' to ' '" },
+        { char = 4, expected_byte = 6, desc = "' ' to 'T'" },
+      }
+
+      for _, pos in ipairs(positions) do
+        local result = util.char_to_byte_col(line, pos.char)
+        print(
+          string.format("char_to_byte_col(%d) = %d (expected %d) -- %s", pos.char, result, pos.expected_byte, pos.desc)
+        )
+
+        -- For debugging, let's also check what vim.str_byteindex returns directly
+        local ok, vim_result = pcall(vim.str_byteindex, line, "utf-8", pos.char)
+        if ok then
+          print(string.format("  vim.str_byteindex(%d) = %d", pos.char, vim_result))
+        else
+          print(string.format("  vim.str_byteindex(%d) = ERROR", pos.char))
+        end
+      end
+    end)
+
+    it("should test different approaches", function()
+      local line = "- □ Test"
+
+      print("\n=== Testing different Neovim APIs ===")
+      print("Line: '" .. line .. "'")
+      print("Byte length: " .. #line)
+
+      -- Method 1: Using string.len vs vim.fn.strchars
+      print("\nMethod 1: String length functions")
+      print("string.len: " .. string.len(line))
+      print("vim.fn.strchars: " .. vim.fn.strchars(line))
+      print("vim.fn.strlen: " .. vim.fn.strlen(line))
+      print("vim.fn.strdisplaywidth: " .. vim.fn.strdisplaywidth(line))
+
+      -- Method 2: Testing vim.fn.byteidx
+      print("\nMethod 2: vim.fn.byteidx")
+      for char_idx = 0, 6 do
+        local byte_idx = vim.fn.byteidx(line, char_idx)
+        print(string.format("char %d -> byte %d", char_idx, byte_idx))
+      end
+
+      -- Method 3: Testing vim.fn.charidx
+      print("\nMethod 3: vim.fn.charidx")
+      for byte_idx = 0, 9 do
+        local char_idx = vim.fn.charidx(line, byte_idx)
+        print(string.format("byte %d -> char %d", byte_idx, char_idx))
+      end
+
+      -- Method 4: Let's manually verify the byte structure
+      print("\nManual byte verification:")
+      local i = 1
+      local char_count = 0
+      while i <= #line do
+        local byte = string.byte(line, i)
+        local char_start = i - 1 -- Convert to 0-based
+
+        if byte < 0x80 then
+          print(string.format("Char %d: ASCII '%s' at byte %d", char_count, string.sub(line, i, i), char_start))
+          i = i + 1
+        elseif byte >= 0xE0 and byte < 0xF0 then
+          print(string.format("Char %d: 3-byte UTF-8 at bytes %d-%d", char_count, char_start, char_start + 2))
+          i = i + 3
+        else
+          print(string.format("Char %d: Unknown at byte %d", char_count, char_start))
+          i = i + 1
+        end
+        char_count = char_count + 1
+      end
+    end)
+    it("should confirm nvim_buf_set_text uses byte positions", function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "- □ Test" })
+
+      -- Replace "□" (at byte 2, length 3) with "✔"
+      vim.api.nvim_buf_set_text(bufnr, 0, 2, 0, 5, { "✔" })
+
+      local result = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+      assert.equal("- ✔ Test", result)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("should confirm nvim_buf_set_extmark uses byte positions", function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local ns = vim.api.nvim_create_namespace("test")
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "- □ Test" })
+
+      -- Highlight "□" (bytes 2-5)
+      local id = vim.api.nvim_buf_set_extmark(bufnr, ns, 0, 2, {
+        end_col = 5,
+        hl_group = "Error",
+      })
+
+      local mark = vim.api.nvim_buf_get_extmark_by_id(bufnr, ns, id, { details = true })
+      assert.equal(2, mark[2]) -- start col
+      assert.equal(5, mark[3].end_col) -- end col
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it("should confirm nvim_win_get_cursor returns byte position", function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "- □ Test" })
+
+      local win = vim.api.nvim_open_win(bufnr, true, {
+        relative = "editor",
+        width = 20,
+        height = 1,
+        row = 1,
+        col = 1,
+        style = "minimal",
+      })
+
+      -- Set cursor after "□" (byte position 5)
+      vim.api.nvim_win_set_cursor(win, { 1, 5 })
+      local cursor = vim.api.nvim_win_get_cursor(win)
+      assert.equal(5, cursor[2]) -- Confirms it's byte position
+
+      vim.api.nvim_win_close(win, true)
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end) ]]
+
+  describe("util conversion functions", function()
+    it("should correctly convert between byte and character positions for ASCII", function()
+      local line = "- [ ] Simple task"
+
+      -- Test char_to_byte_col
+      assert.equal(0, util.char_to_byte_col(line, 0)) -- Start of line
+      assert.equal(2, util.char_to_byte_col(line, 2)) -- '[' character
+      assert.equal(6, util.char_to_byte_col(line, 6)) -- 'S' character
+      assert.equal(17, util.char_to_byte_col(line, 17)) -- End of line
+
+      -- Test byte_to_char_col
+      assert.equal(0, util.byte_to_char_col(line, 0)) -- Start of line
+      assert.equal(2, util.byte_to_char_col(line, 2)) -- '[' character
+      assert.equal(6, util.byte_to_char_col(line, 6)) -- 'S' character
+      assert.equal(17, util.byte_to_char_col(line, 17)) -- End of line
+    end)
+
+    it("should correctly convert between byte and character positions for Unicode", function()
+      -- □ is 3 bytes, ✔ is 3 bytes
+      local line = "- □ Test with ✔ symbols"
+
+      -- Test char_to_byte_col
+      assert.equal(0, util.char_to_byte_col(line, 0)) -- Start of line
+      assert.equal(2, util.char_to_byte_col(line, 2)) -- Start of □ (byte 2)
+      assert.equal(5, util.char_to_byte_col(line, 3)) -- Space after □ (byte 5 = 2 + 3)
+      assert.equal(6, util.char_to_byte_col(line, 4)) -- 'T' (byte 6)
+      assert.equal(15, util.char_to_byte_col(line, 13)) -- Space before ✔ (byte 15)
+      assert.equal(16, util.char_to_byte_col(line, 14)) -- Start of ✔ (byte 16)
+      assert.equal(19, util.char_to_byte_col(line, 15)) -- Space after ✔ (byte 19 = 16 + 3)
+
+      -- Test byte_to_char_col
+      assert.equal(0, util.byte_to_char_col(line, 0)) -- Start of line
+      assert.equal(2, util.byte_to_char_col(line, 2)) -- Start of □
+      assert.equal(3, util.byte_to_char_col(line, 5)) -- Space after □
+      assert.equal(4, util.byte_to_char_col(line, 6)) -- 'T'
+      assert.equal(12, util.byte_to_char_col(line, 14)) -- Space before ✔
+      assert.equal(13, util.byte_to_char_col(line, 15)) -- Start of ✔
+      assert.equal(14, util.byte_to_char_col(line, 18)) -- Space after ✔
+    end)
+
+    it("should handle multi-byte Unicode characters correctly", function()
+      -- Test with various Unicode characters of different byte lengths
+      local line = "🚀 火 € → test" -- 🚀=4 bytes, 火=3 bytes, €=3 bytes, →=3 bytes
+
+      -- Verify byte positions
+      assert.equal(0, util.char_to_byte_col(line, 0)) -- Start
+      assert.equal(4, util.char_to_byte_col(line, 1)) -- Space after 🚀
+      assert.equal(5, util.char_to_byte_col(line, 2)) -- Start of 火
+      assert.equal(8, util.char_to_byte_col(line, 3)) -- Space after 火
+      assert.equal(9, util.char_to_byte_col(line, 4)) -- Start of €
+      assert.equal(12, util.char_to_byte_col(line, 5)) -- Space after €
+      assert.equal(13, util.char_to_byte_col(line, 6)) -- Start of →
+      assert.equal(16, util.char_to_byte_col(line, 7)) -- Space after →
+    end)
+
+    it("should handle edge cases correctly", function()
+      -- Empty string
+      assert.equal(0, util.char_to_byte_col("", 0))
+      assert.equal(0, util.byte_to_char_col("", 0))
+
+      -- Position beyond string length
+      local line = "test"
+      assert.equal(4, util.char_to_byte_col(line, 10)) -- Should clamp to string length
+      assert.equal(4, util.byte_to_char_col(line, 10)) -- Should clamp to string length
+    end)
+  end)
+end)


### PR DESCRIPTION
- Stable Todo IDs via Extmarks
  - Switched from using Tree-sitter node IDs to Neovim extmark IDs as each todo’s id.
  - Extmarks are placed at the todo marker position and survive buffer edits, so item identity is preserved across operations.

- Transaction System for Atomic Updates
  - Introduced lua/checkmate/transaction.lua to batch all API operations into a single, atomic transaction.
  - Transactions queue operations (state toggles, metadata edits, etc.), compute diffs, apply them, refresh the todo map, then run post-transaction callbacks (e.g. highlighting).

- Diff-Based Editing Engine
  - All buffer changes in checkmate.api now generate fine-grained TextDiffHunks (e.g. just replacing the marker character or inserting metadata) and apply them via api.apply_diff.
  - This minimizes buffer churn, preserves extmarks, and keeps undo histories cleaner.

- Precise Char ↔ Byte Column Handling
  - Added util.char_to_byte_col and util.byte_to_char_col to convert between user-facing character indices and Neovim’s byte indices.
  - Internal data structures store byte positions; conversion only happens when calling Neovim APIs.

- Parser Overhaul
  - discover_todos now:
    - Keys its map by extmark ID (integer) instead of TS node ID.
    - Reuses existing extmarks when possible and cleans up orphaned ones.
    - Records both a raw ts_range and a semantic range (checkmate.Range).
  - get_todo_item_at_position first looks up extmarks on the current row, then falls back to TS-based logic.
  - Added parser.get_todo_position helper to retrieve an item’s live extmark position.
  - Cache todo patterns used by parser
  
- Util
  - Improved implementation of batched buffer lines access with batch_get_lines

- Highlights
  - Improved line cache implementation that uses batch_get_lines

- API Simplification & New Primitives
  - Removed the old apply_todo_operation wrapper and direct buf_set_* calls in favor of:
    - compute_diff_toggle, toggle_state, set_todo_item, compute_diff_add_metadata, etc.
  - These primitives are orchestrated by the transaction engine to produce diffs and maintain consistency.

- Configuration & Namespaces
  - Added a dedicated config.ns_todos namespace for todo-item extmarks (distinct from the general plugin namespace).
  - Keymap setup logic in api.setup_keymaps streamlined to skip disabled mappings cleanly.

- Utility Enhancements
  - util.get_buffer_lines for bulk line fetching by row list.
  - Updated util.get_sorted_todo_list to reflect integer-keyed maps.
  - Improved metadata extraction to use byte-based positions and unified MetadataEntry.range.

- Performance Profiling Hooks
  - Integrated checkmate.profiler around hot paths (e.g. parser.discover_todos, M.toggle, M.toggle_metadata) to measure and optimize.

- Breaking Changes & Migration Notes
  - Internal API Removal
    - checkmate.api.apply_todo_operation and old toggle_todo_item, apply_metadata, remove_metadata, etc. have been removed.
  - Todo-Item IDs Changed
    - IDs are now extmark IDs, not TS node IDs; any persisted references to node IDs are invalid.
  - Public API Signatures
    - All public actions (toggle, set_todo_item, metadata functions, etc.) now return boolean and always run within transactions, which may subtly alter timing or return values in edge cases.