### PR TITLE
Refactor/transaction

### DIFF
--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -7,7 +7,7 @@
 local M = {}
 
 -- Set to true during development to include debug commands
-local INCLUDE_DEBUG_COMMANDS = false
+local INCLUDE_DEBUG_COMMANDS = true
 
 -- Regular commands that are always available
 ---@type CheckmateCommand[]

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -7,7 +7,7 @@
 local M = {}
 
 -- Set to true during development to include debug commands
-local INCLUDE_DEBUG_COMMANDS = true
+local INCLUDE_DEBUG_COMMANDS = false
 
 -- Regular commands that are always available
 ---@type CheckmateCommand[]

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -227,7 +227,12 @@ function M.toggle(target_state)
       if smart_toggle_enabled then
         api.propagate_toggle(ctx, { todo_item }, transaction._state.todo_map, target_state)
       else
-        ctx.add_op(api.toggle_state, todo_item.id, target_state)
+        ctx.add_op(api.toggle_state, {
+          {
+            id = todo_item.id,
+            target_state = target_state or (todo_item.state == "unchecked" and "checked" or "unchecked"),
+          },
+        })
       end
     end
     profiler.stop("M.toggle")
@@ -236,16 +241,24 @@ function M.toggle(target_state)
 
   local is_visual = util.is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  -- we go ahead a keep the parsed todo_map so that we can initialize the transaction below without it
-  -- also having to discover_todos
   local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
 
-  transaction.run(bufnr, todo_map, function(_ctx)
+  transaction.run(bufnr, function(_ctx)
     if smart_toggle_enabled then
       api.propagate_toggle(_ctx, todo_items, todo_map, target_state)
     else
+      local operations = {}
+
       for _, item in ipairs(todo_items) do
-        _ctx.add_op(api.toggle_state, item.id, target_state)
+        table.insert(operations, {
+          id = item.id,
+          target_state = target_state or (item.state == "unchecked" and "checked" or "unchecked"),
+        })
+      end
+
+      -- Single batched operation
+      if #operations > 0 then
+        _ctx.add_op(api.toggle_state, operations)
       end
     end
   end, function()
@@ -278,7 +291,10 @@ function M.set_todo_item(todo_item, target_state)
       local todo_map = transaction._state.todo_map
       api.propagate_toggle(ctx, { todo_item }, todo_map, target_state)
     else
-      ctx.add_op(api.set_todo_item, todo_id, target_state)
+      ctx.add_op(api.toggle_state, { {
+        id = todo_id,
+        target_state = target_state,
+      } })
     end
     return true
   end
@@ -288,11 +304,14 @@ function M.set_todo_item(todo_item, target_state)
   -- If smart toggle is enabled, we need the todo_map
   local todo_map = smart_toggle_enabled and parser.get_todo_map(bufnr) or nil
 
-  transaction.run(bufnr, todo_map, function(_ctx)
+  transaction.run(bufnr, function(_ctx)
     if smart_toggle_enabled and todo_map then
       api.propagate_toggle(_ctx, { todo_item }, todo_map, target_state)
     else
-      _ctx.add_op(api.set_todo_item, todo_id, target_state)
+      _ctx.add_op(api.toggle_state, { {
+        id = todo_id,
+        target_state = target_state,
+      } })
     end
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
@@ -349,14 +368,14 @@ function M.add_metadata(metadata_name, value)
     local todo_item =
       parser.get_todo_item_at_position(ctx.bufnr, cursor[1] - 1, cursor[2], { todo_map = transaction._state.todo_map })
     if todo_item then
-      ctx.add_op(api.add_metadata, todo_item.id, metadata_name, value)
+      ctx.add_op(api.add_metadata, { { id = todo_item.id, meta_name = metadata_name, meta_value = value } })
     end
     return true
   end
 
   local is_visual = util.is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
+  local todo_items = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -364,11 +383,19 @@ function M.add_metadata(metadata_name, value)
     return false
   end
 
+  -- Build operations array
+  local operations = {}
+  for _, item in ipairs(todo_items) do
+    table.insert(operations, {
+      id = item.id,
+      meta_name = metadata_name,
+      meta_value = value,
+    })
+  end
+
   -- Begin a transaction
-  transaction.run(bufnr, todo_map, function(_ctx)
-    for _, item in ipairs(todo_items) do
-      _ctx.add_op(api.add_metadata, item.id, metadata_name, value)
-    end
+  transaction.run(bufnr, function(_ctx)
+    _ctx.add_op(api.add_metadata, operations)
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
   end)
@@ -392,14 +419,14 @@ function M.remove_metadata(metadata_name)
     local todo_item =
       parser.get_todo_item_at_position(ctx.bufnr, cursor[1] - 1, cursor[2], { todo_map = transaction._state.todo_map })
     if todo_item then
-      ctx.add_op(api.remove_metadata, todo_item.id, metadata_name)
+      ctx.add_op(api.remove_metadata, { { id = todo_item.id, meta_name = metadata_name } })
     end
     return true
   end
 
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
+  local todo_items = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -407,10 +434,16 @@ function M.remove_metadata(metadata_name)
     return false
   end
 
-  transaction.run(bufnr, todo_map, function(_ctx)
-    for _, item in ipairs(todo_items) do
-      _ctx.add_op(api.remove_metadata, item.id, metadata_name)
-    end
+  local operations = {}
+  for _, item in ipairs(todo_items) do
+    table.insert(operations, {
+      id = item.id,
+      meta_name = metadata_name,
+    })
+  end
+
+  transaction.run(bufnr, function(_ctx)
+    _ctx.add_op(api.remove_metadata, operations)
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
   end)
@@ -433,14 +466,14 @@ function M.remove_all_metadata()
     local todo_item =
       parser.get_todo_item_at_position(ctx.bufnr, cursor[1] - 1, cursor[2], { todo_map = transaction._state.todo_map })
     if todo_item then
-      ctx.add_op(api.remove_all_metadata, todo_item.id)
+      ctx.add_op(api.remove_all_metadata, { todo_item.id })
     end
     return true
   end
 
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
+  local todo_items = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -448,10 +481,12 @@ function M.remove_all_metadata()
     return false
   end
 
-  transaction.run(bufnr, todo_map, function(_ctx)
-    for _, item in ipairs(todo_items) do
-      _ctx.add_op(api.remove_all_metadata, item.id)
-    end
+  local ids = vim.tbl_map(function(item)
+    return item.id
+  end, todo_items)
+
+  transaction.run(bufnr, function(_ctx)
+    _ctx.add_op(api.remove_all_metadata, ids)
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
   end)
@@ -479,7 +514,7 @@ function M.toggle_metadata(meta_name, custom_value)
     local todo_item =
       parser.get_todo_item_at_position(ctx.bufnr, cursor[1] - 1, cursor[2], { todo_map = transaction._state.todo_map })
     if todo_item then
-      ctx.add_op(api.toggle_metadata, todo_item.id, meta_name, custom_value)
+      ctx.add_op(api.toggle_metadata, { { id = todo_item.id, meta_name = meta_name, custom_value = custom_value } })
     end
     profiler.stop("M.toggle_metadata")
     return true
@@ -487,7 +522,7 @@ function M.toggle_metadata(meta_name, custom_value)
 
   local is_visual = require("checkmate.util").is_visual_mode()
   local bufnr = vim.api.nvim_get_current_buf()
-  local todo_items, todo_map = api.collect_todo_items_from_selection(is_visual)
+  local todo_items = api.collect_todo_items_from_selection(is_visual)
 
   if #todo_items == 0 then
     local mode_msg = is_visual and "selection" or "cursor position"
@@ -495,10 +530,17 @@ function M.toggle_metadata(meta_name, custom_value)
     return false
   end
 
-  transaction.run(bufnr, todo_map, function(_ctx)
-    for _, item in ipairs(todo_items) do
-      _ctx.add_op(api.toggle_metadata, item.id, meta_name, custom_value)
-    end
+  local operations = {}
+  for _, item in ipairs(todo_items) do
+    table.insert(operations, {
+      id = item.id,
+      meta_name = meta_name,
+      custom_value = custom_value,
+    })
+  end
+
+  transaction.run(bufnr, function(_ctx)
+    _ctx.add_op(api.toggle_metadata, operations)
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
   end)
@@ -574,7 +616,6 @@ end
 
 --- Inspect todo item at cursor
 function M.debug_at_cursor()
-  local log = require("checkmate.log")
   local parser = require("checkmate.parser")
   local config = require("checkmate.config")
   local util = require("checkmate.util")

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -217,7 +217,7 @@ function M.toggle(target_state)
 
   local ctx = transaction.current_context()
   if ctx then
-    -- Queue the operation in the current transaction
+    -- queue the operation in the current transaction
     -- If toggle() is run within an existing transaction, we will use the cursor position
     local parser = require("checkmate.parser")
     local cursor = vim.api.nvim_win_get_cursor(0)
@@ -256,7 +256,6 @@ function M.toggle(target_state)
         })
       end
 
-      -- Single batched operation
       if #operations > 0 then
         _ctx.add_op(api.toggle_state, operations)
       end
@@ -301,7 +300,7 @@ function M.set_todo_item(todo_item, target_state)
 
   local bufnr = vim.api.nvim_get_current_buf()
 
-  -- If smart toggle is enabled, we need the todo_map
+  -- if smart toggle is enabled, we need the todo_map
   local todo_map = smart_toggle_enabled and parser.get_todo_map(bufnr) or nil
 
   transaction.run(bufnr, function(_ctx)
@@ -361,8 +360,7 @@ function M.add_metadata(metadata_name, value)
 
   local ctx = transaction.current_context()
   if ctx then
-    -- Queue the operation in the current transaction
-    -- If add_metadata() is run within an existing transaction, we will use the cursor position
+    -- if add_metadata() is run within an existing transaction, we will use the cursor position
     local parser = require("checkmate.parser")
     local cursor = vim.api.nvim_win_get_cursor(0)
     local todo_item =
@@ -383,7 +381,6 @@ function M.add_metadata(metadata_name, value)
     return false
   end
 
-  -- Build operations array
   local operations = {}
   for _, item in ipairs(todo_items) do
     table.insert(operations, {
@@ -393,7 +390,6 @@ function M.add_metadata(metadata_name, value)
     })
   end
 
-  -- Begin a transaction
   transaction.run(bufnr, function(_ctx)
     _ctx.add_op(api.add_metadata, operations)
   end, function()
@@ -412,8 +408,7 @@ function M.remove_metadata(metadata_name)
 
   local ctx = transaction.current_context()
   if ctx then
-    -- Queue the operation in the current transaction
-    -- If remove_metadata() is run within an existing transaction, we will use the cursor position
+    -- if remove_metadata() is run within an existing transaction, we will use the cursor position
     local parser = require("checkmate.parser")
     local cursor = vim.api.nvim_win_get_cursor(0)
     local todo_item =
@@ -459,8 +454,7 @@ function M.remove_all_metadata()
 
   local ctx = transaction.current_context()
   if ctx then
-    -- Queue the operation in the current transaction
-    -- If remove_all_metadata() is run within an existing transaction, we will use the cursor position
+    -- if remove_all_metadata() is run within an existing transaction, we will use the cursor position
     local parser = require("checkmate.parser")
     local cursor = vim.api.nvim_win_get_cursor(0)
     local todo_item =
@@ -507,8 +501,7 @@ function M.toggle_metadata(meta_name, custom_value)
 
   local ctx = transaction.current_context()
   if ctx then
-    -- Queue the operation in the current transaction
-    -- If toggle_metadata() is run within an existing transaction, we will use the cursor position
+    -- if toggle_metadata() is run within an existing transaction, we will use the cursor position
     local parser = require("checkmate.parser")
     local cursor = vim.api.nvim_win_get_cursor(0)
     local todo_item =

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -6,17 +6,6 @@ local api = require("checkmate.api")
 
 M._state = nil
 
--- Helper: Group operations by their API function
-local function group_by_fn(ops)
-  local batches = {}
-  for _, op in ipairs(ops) do
-    local fn = op.fn
-    batches[fn] = batches[fn] or {}
-    table.insert(batches[fn], op)
-  end
-  return batches
-end
-
 function M.is_active()
   return M._state ~= nil
 end
@@ -32,19 +21,18 @@ end
 
 --- Starts a transaction for a buffer
 ---@param bufnr number Buffer number
----@param todo_map table<integer, checkmate.TodoItem>? Optional todo_map to initialize state. Only pass if guaranteed fresh.
 ---@param entry_fn function Function to start the transaction
 ---@param post_fn function? Function to run after transaction completes
-function M.run(bufnr, todo_map, entry_fn, post_fn)
+function M.run(bufnr, entry_fn, post_fn)
   assert(not M._state, "Nested transactions are not supported")
 
   -- Initialize transaction state
   local state = {
     bufnr = bufnr,
-    todo_map = todo_map or parser.get_todo_map(bufnr),
+    todo_map = parser.get_todo_map(bufnr),
     op_queue = {},
     cb_queue = {},
-    seen_ops = {},
+    seen_ops = {}, --dedupe identical ops
   }
 
   -- Create the transaction context
@@ -59,16 +47,22 @@ function M.run(bufnr, todo_map, entry_fn, post_fn)
       return M._state.todo_map[extmark_id]
     end,
 
-    -- Queue an API operation
-    add_op = function(fn, extmark_id, ...)
+    --- Queue any function and its arguments
+    --- @param fn function  the fn must return checkmate.TextHunkDiff[] or nil or {}
+    --- @param ... any      args to pass when we actually call `fn(...)`.
+    add_op = function(fn, ...)
       local fn_name = debug.getinfo(fn, "n").name or tostring(fn)
-      local key = fn_name .. ":" .. tostring(extmark_id)
-      if not M._state.seen_ops[key] then
-        M._state.seen_ops[key] = true
+
+      local seen_key = fn_name
+      for i = 1, select("#", ...) do
+        seen_key = seen_key .. "|" .. tostring(select(i, ...))
+      end
+
+      if not M._state.seen_ops[seen_key] then
+        M._state.seen_ops[seen_key] = true
         table.insert(M._state.op_queue, {
           fn = fn,
-          extmark_id = extmark_id,
-          params = { ... },
+          args = { ... },
         })
       end
     end,
@@ -86,54 +80,28 @@ function M.run(bufnr, todo_map, entry_fn, post_fn)
 
   M._state = state
 
-  -- Execute the entry function
   entry_fn(state.context)
 
   -- Transaction loop: process operations and callbacks until both queues are empty
   while #M._state.op_queue > 0 or #M._state.cb_queue > 0 do
-    -- Process all queued operations
     if #M._state.op_queue > 0 then
-      local ops = M._state.op_queue
+      local queued = M._state.op_queue
       M._state.op_queue = {}
 
-      -- Group operations by function for batch processing
-      local grouped = group_by_fn(ops)
+      for _, op in ipairs(queued) do
+        local hunks = op.fn(state.context, unpack(op.args))
 
-      for fn, fn_ops in pairs(grouped) do
-        -- Prepare items and params arrays for the API function
-        local items = {}
-        local params = {}
-
-        for _, op in ipairs(fn_ops) do
-          -- Find the item using the string ID
-          local item = M._state.todo_map[op.extmark_id]
-          if item then
-            table.insert(items, item)
-            table.insert(params, op.params)
-          end
-        end
-
-        if #items > 0 then
-          -- Call the API function with proper signature
-          local hunks = fn(items, params, state.context)
-
-          -- Apply the diff if we got hunks back
-          if hunks and #hunks > 0 then
-            api.apply_diff(bufnr, hunks)
-            -- Refresh the todo map after buffer changes
-            M._state.todo_map = parser.discover_todos(bufnr)
-          end
+        if hunks and #hunks > 0 then
+          api.apply_diff(bufnr, hunks)
+          M._state.todo_map = parser.discover_todos(bufnr)
         end
       end
     end
-
-    -- Process all queued callbacks
     if #M._state.cb_queue > 0 then
       local cbs = M._state.cb_queue
       M._state.cb_queue = {}
 
       for _, cb in ipairs(cbs) do
-        -- Execute callback with transaction context
         cb.cb_fn(state.context, unpack(cb.params))
       end
     end

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -79,8 +79,8 @@ function M.run(bufnr, entry_fn, post_fn)
     end,
 
     --- Queue any function and its arguments
-    --- @param fn function  the fn must return checkmate.TextHunkDiff[] or nil or {}
-    --- @param ... any      args to pass when we actually call `fn(...)`.
+    --- @param fn function fn must return checkmate.TextHunkDiff[] or nil or {}
+    --- @param ... any args to pass when we actually call `fn(...)`
     add_op = function(fn, ...)
       local fn_name = debug.getinfo(fn, "n").name or tostring(fn)
 
@@ -140,7 +140,9 @@ function M.run(bufnr, entry_fn, post_fn)
       M._state.cb_queue = {}
 
       for _, cb in ipairs(cbs) do
-        cb.cb_fn(state.context, unpack(cb.params))
+        pcall(function()
+          cb.cb_fn(state.context, unpack(cb.params))
+        end)
       end
     end
   end

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -1,4 +1,35 @@
--- checkmate/transaction.lua
+--[[
+Transaction Module 
+
+provides a context for grouping diff generating operations and related callbacks
+into “transactions” so that expensive steps (e.g., discover_todos) run only once
+per batch, even if many operations or callbacks are queued.
+
+op (operation):
+  – A function (plus its original args) that returns zero or more TextDiffHunk[]
+  – All queued ops are collected each loop iteration; their hunks are merged,
+    applied once via api.apply_diff, then parser.discover_todos is called exactly once.
+callback (cb):
+  – A function (plus its args) meant to run after the current batch of ops is applied
+  – All queued callbacks run only after the todo map has been refreshed (discover_todos).
+  – Callbacks can themselves enqueue new ops or callbacks for the next iteration.
+
+some notes on the internals (inside M.run):
+  1. entry_fn(context) runs, letting plugin code queue up ops/cbs.
+  2. While there are ops or cbs:
+     a. If op_queue is nonempty:
+       - Pull all ops at once → call op.fn for each, collect all diff hunks → api.apply_diff(bufnr, all_hunks) → parser.discover_todos(bufnr).
+     b. If cb_queue is nonempty:
+       - Pull all callbacks at once → run each cb_fn(context, ...)
+       - Any new ops/cbs now sit in op_queue/cb_queue for next loop iteration.
+  3. After both queues drain, optional post_fn() is invoked and transaction ends.
+
+remember...
+  - callbacks should not directly mutate buffer state; they should queue ops via add_op
+  - batching ensures that discover_todos() is called exactly once per group of ops,
+    minimizing expensive recomputation even if many todo items operated on
+]]
+--
 
 local M = {}
 local parser = require("checkmate.parser")
@@ -82,21 +113,28 @@ function M.run(bufnr, entry_fn, post_fn)
 
   entry_fn(state.context)
 
-  -- Transaction loop: process operations and callbacks until both queues are empty
+  -- transaction loop: process operations and callbacks until both queues are empty
   while #M._state.op_queue > 0 or #M._state.cb_queue > 0 do
     if #M._state.op_queue > 0 then
       local queued = M._state.op_queue
       M._state.op_queue = {}
 
+      -- collect every diff from each op into a single array
+      local all_hunks = {}
       for _, op in ipairs(queued) do
+        -- call op.fn(context, unpack(op.args))
         local hunks = op.fn(state.context, unpack(op.args))
-
         if hunks and #hunks > 0 then
-          api.apply_diff(bufnr, hunks)
-          M._state.todo_map = parser.discover_todos(bufnr)
+          vim.list_extend(all_hunks, hunks)
         end
       end
+
+      if #all_hunks > 0 then
+        api.apply_diff(bufnr, all_hunks)
+        M._state.todo_map = parser.discover_todos(bufnr)
+      end
     end
+
     if #M._state.cb_queue > 0 then
       local cbs = M._state.cb_queue
       M._state.cb_queue = {}

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -1977,7 +1977,7 @@ Some content here
       assert.equal("unchecked", todo.state)
 
       -- compute the diff to check it
-      local hunks = api.compute_diff_toggle({ todo }, "checked")
+      local hunks = api.compute_diff_toggle({ { item = todo, target_state = "checked" } })
       assert.equal(1, #hunks)
 
       local hunk = hunks[1]

--- a/tests/checkmate/transaction_spec.lua
+++ b/tests/checkmate/transaction_spec.lua
@@ -23,12 +23,12 @@ describe("Transaction", function()
     assert.is_false(transaction.is_active())
 
     -- Run a transaction that toggles TaskX to 'checked'
-    transaction.run(bufnr, nil, function(ctx)
+    transaction.run(bufnr, function(ctx)
       local todo_map = parser.discover_todos(bufnr)
       local todo = h.find_todo_by_text(todo_map, "TaskX")
       assert.is_not_nil(todo)
       ---@cast todo checkmate.TodoItem
-      ctx.add_op(api.toggle_state, todo.id, "checked")
+      ctx.add_op(api.toggle_state, { { id = todo.id, target_state = "checked" } })
     end, function()
       -- Post-transaction: buffer line should now show checked marker
       local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
@@ -50,7 +50,7 @@ describe("Transaction", function()
     local received = nil
 
     -- Run a transaction that only queues a callback
-    require("checkmate.transaction").run(bufnr, nil, function(ctx)
+    require("checkmate.transaction").run(bufnr, function(ctx)
       ctx.add_cb(function(_, val)
         called = true
         received = val

--- a/tests/checkmate/transaction_spec.lua
+++ b/tests/checkmate/transaction_spec.lua
@@ -1,6 +1,10 @@
 describe("Transaction", function()
   local h = require("tests.checkmate.helpers")
 
+  local transaction = require("checkmate.transaction")
+  local parser = require("checkmate.parser")
+  local api = require("checkmate.api")
+
   before_each(function()
     _G.reset_state()
 
@@ -9,10 +13,6 @@ describe("Transaction", function()
 
   it("should apply queued operations and clear state", function()
     local config = require("checkmate.config")
-    local transaction = require("checkmate.transaction")
-    local parser = require("checkmate.parser")
-    local api = require("checkmate.api")
-
     local unchecked = config.options.todo_markers.unchecked
     local checked = config.options.todo_markers.checked
 
@@ -30,7 +30,7 @@ describe("Transaction", function()
       ---@cast todo checkmate.TodoItem
       ctx.add_op(api.toggle_state, { { id = todo.id, target_state = "checked" } })
     end, function()
-      -- Post-transaction: buffer line should now show checked marker
+      -- buffer line should now show checked marker
       local line = vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
       assert.matches(checked, line)
     end)
@@ -49,7 +49,7 @@ describe("Transaction", function()
     local called = false
     local received = nil
 
-    -- Run a transaction that only queues a callback
+    -- transaction that only queues a callback
     require("checkmate.transaction").run(bufnr, function(ctx)
       ctx.add_cb(function(_, val)
         called = true
@@ -59,6 +59,160 @@ describe("Transaction", function()
 
     assert.is_true(called)
     assert.equal(123, received)
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+
+  it("should batch multiple operations into single apply_diff call", function()
+    local config = require("checkmate.config")
+    local unchecked = config.options.todo_markers.unchecked
+    local content = [[
+- ]] .. unchecked .. [[ Task 1
+- ]] .. unchecked .. [[ Task 2
+- ]] .. unchecked .. [[ Task 3 ]]
+    local bufnr = h.create_test_buffer(content)
+
+    local apply_diff_called = 0
+    local original_apply_diff = api.apply_diff
+    api.apply_diff = function(...)
+      apply_diff_called = apply_diff_called + 1
+      return original_apply_diff(...)
+    end
+
+    transaction.run(bufnr, function(ctx)
+      local todo_map = parser.discover_todos(bufnr)
+      for _, todo in pairs(todo_map) do
+        ctx.add_op(api.toggle_state, { { id = todo.id, target_state = "checked" } })
+      end
+    end)
+
+    -- should only call apply_diff once for all operations
+    assert.equal(1, apply_diff_called)
+
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    for _, line in ipairs(lines) do
+      assert.matches(config.options.todo_markers.checked, line)
+    end
+
+    api.apply_diff = original_apply_diff
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+
+  it("should update todo map after operations for subsequent callbacks", function()
+    local config = require("checkmate.config")
+    local unchecked = config.options.todo_markers.unchecked
+    local checked = config.options.todo_markers.checked
+    local content = "- " .. unchecked .. " Task1"
+    local bufnr = h.create_test_buffer(content)
+
+    local states_in_callback = {}
+
+    transaction.run(bufnr, function(ctx)
+      local todo_map = parser.discover_todos(bufnr)
+      local todo = h.find_todo_by_text(todo_map, "Task1")
+      if not todo then
+        error("missing todo")
+      end
+
+      -- Queue operation to toggle to checked
+      ctx.add_op(api.toggle_state, { { id = todo.id, target_state = "checked" } })
+
+      -- Queue callback that should see updated state
+      ctx.add_cb(function(cb_ctx)
+        local updated_todo = cb_ctx.get_item(todo.id)
+        table.insert(states_in_callback, updated_todo.state)
+      end)
+    end)
+
+    -- Callback should see the checked state
+    assert.equal(1, #states_in_callback)
+    assert.equal("checked", states_in_callback[1])
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+
+  it("should execute callbacks after all operations in a batch", function()
+    local config = require("checkmate.config")
+
+    local unchecked = config.options.todo_markers.unchecked
+    local content = [[
+- ]] .. unchecked .. [[ Task 1
+- ]] .. unchecked .. [[ Task 2
+]]
+    local bufnr = h.create_test_buffer(content)
+
+    local execution_order = {}
+
+    transaction.run(bufnr, function(ctx)
+      local todo_map = parser.discover_todos(bufnr)
+
+      for _, todo in pairs(todo_map) do
+        ctx.add_op(function()
+          table.insert(execution_order, "op:" .. todo.todo_text:match("Task %d"))
+          return {} -- No actual diff
+        end)
+      end
+
+      ctx.add_cb(function()
+        table.insert(execution_order, "cb:1")
+      end)
+
+      ctx.add_cb(function()
+        table.insert(execution_order, "cb:2")
+      end)
+    end)
+
+    -- operations should execute before callbacks
+    assert.equal(4, #execution_order)
+    assert.truthy(execution_order[1]:match("^op:"))
+    assert.truthy(execution_order[2]:match("^op:"))
+    assert.equal("cb:1", execution_order[3])
+    assert.equal("cb:2", execution_order[4])
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+
+  it("should provide current_context when transaction is active", function()
+    local bufnr = h.create_test_buffer("")
+    local context_inside = nil
+    local context_outside = transaction.current_context()
+
+    assert.is_nil(context_outside)
+
+    transaction.run(bufnr, function(ctx)
+      context_inside = transaction.current_context()
+      assert.is_not_nil(context_inside)
+      assert.equal(ctx, context_inside)
+    end)
+
+    context_outside = transaction.current_context()
+    assert.is_nil(context_outside)
+
+    finally(function()
+      h.cleanup_buffer(bufnr)
+    end)
+  end)
+
+  it("should execute post function after transaction completes", function()
+    local bufnr = h.create_test_buffer("")
+    local post_called = false
+
+    transaction.run(bufnr, function()
+      -- empty txn
+    end, function()
+      post_called = true
+    end)
+
+    assert.is_true(post_called)
 
     finally(function()
       h.cleanup_buffer(bufnr)


### PR DESCRIPTION
Need the transaction module to be more generic with allowed operations. Previously, the add_op function exposed by the transaction ctx was tied too closely to todo items, i.e. expecting the todo ids. Since there are functions that should benefit from the transaction system but may not use todo ids in their signature, we can now instead pass any arbitrary args as we are registering the operation. The internal api now should expect to receive the transaction ctx as the first parameter.