### PR TITLE
add get_todo_by_row and add TransactionContext type

### DIFF
--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -35,6 +35,15 @@ local M = {}
 local parser = require("checkmate.parser")
 local api = require("checkmate.api")
 
+---the exposed transaction state is referred to as "context"
+---the internal state is M._state
+---@class checkmate.TransactionContext
+---@field get_todo_by_id function(id: integer): checkmate.TodoItem
+---@field get_todo_by_row function(row: integer): checkmate.TodoItem
+---@field add_op function(fn: fn, ...)
+---@field add_cb function(fn: fn, ...)
+---@field get_buf function(): integer Returns the buffer
+
 M._state = nil
 
 function M.is_active()
@@ -66,15 +75,23 @@ function M.run(bufnr, entry_fn, post_fn)
   }
 
   -- Create the transaction context
+  ---@type checkmate.TransactionContext
   state.context = {
     -- Get the current (latest) todo item by ID
-    get_item = function(extmark_id)
+    get_todo_by_id = function(extmark_id)
       local item = M._state.todo_map[extmark_id]
       if not item then
-        vim.notify("Could not find extmark_id: " .. extmark_id)
-        vim.notify(vim.inspect(vim.api.nvim_buf_get_extmarks(0, require("checkmate.config").ns_todos, 0, -1, {})))
+        vim.notify("Could not find todo by id: " .. extmark_id)
       end
       return M._state.todo_map[extmark_id]
+    end,
+
+    get_todo_by_row = function(row)
+      local item =
+        require("checkmate.parser").get_todo_item_at_position(M._state.bufnr, row, 0, { todo_map = M._state.todo_map })
+      if not item then
+        vim.notify("Could not find todo by row: " .. row)
+      end
     end,
 
     --- Queue any function and its arguments
@@ -105,7 +122,9 @@ function M.run(bufnr, entry_fn, post_fn)
       })
     end,
 
-    bufnr = bufnr,
+    get_buf = function()
+      return M._state.bufnr
+    end,
   }
 
   M._state = state

--- a/tests/checkmate/transaction_spec.lua
+++ b/tests/checkmate/transaction_spec.lua
@@ -106,7 +106,6 @@ describe("Transaction", function()
   it("should update todo map after operations for subsequent callbacks", function()
     local config = require("checkmate.config")
     local unchecked = config.options.todo_markers.unchecked
-    local checked = config.options.todo_markers.checked
     local content = "- " .. unchecked .. " Task1"
     local bufnr = h.create_test_buffer(content)
 
@@ -124,7 +123,7 @@ describe("Transaction", function()
 
       -- Queue callback that should see updated state
       ctx.add_cb(function(cb_ctx)
-        local updated_todo = cb_ctx.get_item(todo.id)
+        local updated_todo = cb_ctx.get_todo_by_id(todo.id)
         table.insert(states_in_callback, updated_todo.state)
       end)
     end)


### PR DESCRIPTION
Previously, the transaction context only had `get_item` which took a todo id and returned the todo item. We may also want to get a todo by its buffer row, so this adds a `get_todo_by_row` and changes the previous to `get_todo_by_id`.