### PR TITLE
Feat/smarter create todo functionality

### DIFF
--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -585,14 +585,12 @@ function M.compute_diff_convert_to_todo(bufnr, row)
     new_text = indent .. default_marker .. " " .. unchecked .. " " .. line:gsub("^%s*", "")
   end
 
-  local old_len = #line
-
   return {
     {
       start_row = row,
       start_col = 0,
       end_row = row,
-      end_col = old_len,
+      end_col = -1, -- this will force apply_diff to use set_text rather than set_lines
       insert = { new_text },
     },
   }

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -507,6 +507,7 @@ function M.create_todo()
   end
 
   -- extract indentation
+  -- extract indentation
   local indent = line:match("^(%s*)") or ""
 
   -- does the line already start with a list marker

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -405,7 +405,17 @@ function M.uncheck()
   return M.toggle("unchecked")
 end
 
---- Create a new todo (or insert a sibling) at cursor or for each non-todo line in visual selection.
+--- Creates a new todo item
+---
+--- # Behavior
+--- - In normal mode:
+---   - Will convert a line under the cursor to a todo item if it is not one
+---   - Will append a new todo item below the current line, making a sibling todo item, that attempts to match the list marker and indentation
+--- - In visual mode:
+---   - Will convert each line in the selection to a new todo item with the default list marker
+---   - Will ignore existing todo items (first line only). If the todo item spans more than one line, the
+---   additional lines will be converted to individual todos
+---   - Will not append any new todo items even if all lines in the selection are already todo items
 ---@return boolean success
 function M.create()
   local api = require("checkmate.api")
@@ -413,74 +423,44 @@ function M.create()
   local transaction = require("checkmate.transaction")
   local util = require("checkmate.util")
 
-  -- if we’re already inside a transaction, queue a “convert or insert” for the current cursor row
+  -- if we’re already inside a transaction, queue a "create_todos" for the current cursor row
   local ctx = transaction.current_context()
   if ctx then
-    local bufnr = ctx.bufnr or vim.api.nvim_get_current_buf()
     local cursor = vim.api.nvim_win_get_cursor(0)
     local row = cursor[1] - 1
-    local col = cursor[2]
 
-    local todo_item =
-      parser.get_todo_item_at_position(ctx.bufnr, row, col, { todo_map = transaction.get_state().todo_map })
-    if todo_item then
-      ctx.add_op(api.insert_new_todo_below, row)
-    else
-      ctx.add_op(api.convert_line_to_todo, row)
-    end
+    ctx.add_op(api.create_todos, row, row, false)
+
     return true
   end
 
-  -- start new transaction
   local bufnr = vim.api.nvim_get_current_buf()
   local is_visual = util.is_visual_mode()
 
-  local convert_rows = {}
-  local insert_rows = {}
-  local msg_mode = is_visual and "selection" or "cursor position"
-
+  local start_row, end_row
   if is_visual then
     vim.cmd([[normal! <Esc>]])
-    -- get the start/end row (1-based)
+    -- get the sel start/end row (1-based)
     local mark_start = vim.api.nvim_buf_get_mark(bufnr, "<")
     local mark_end = vim.api.nvim_buf_get_mark(bufnr, ">")
-    local start_row = mark_start[1] - 1
-    local end_row = mark_end[1] - 1
+    start_row = mark_start[1] - 1
+    end_row = mark_end[1] - 1
 
-    -- for each selected row, see if it is a todo already
-    for row = start_row, end_row do
-      local line = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ""
-      local state = parser.get_todo_item_state(line)
-      if state == nil then
-        table.insert(convert_rows, row)
-      end
+    if end_row < start_row then
+      start_row, end_row = end_row, start_row
     end
   else
-    -- normal mode: single row under cursor
-    local cursor = vim.api.nvim_win_get_cursor(0)
-    local row = cursor[1] - 1
-    local col = cursor[2]
-    local todo_item = parser.get_todo_item_at_position(bufnr, row, col, { todo_map = parser.get_todo_map(bufnr) })
-
-    if todo_item then
-      table.insert(insert_rows, row)
-    else
-      table.insert(convert_rows, row)
-    end
+    local cur = vim.api.nvim_win_get_cursor(0)
+    start_row = cur[1] - 1
+    end_row = start_row
   end
 
-  if #convert_rows == 0 and #insert_rows == 0 then
+  if not start_row or not end_row then
     return false
   end
 
-  local full_map = parser.get_todo_map(bufnr)
-  transaction.run(bufnr, full_map, function(tx_ctx)
-    for _, row in ipairs(convert_rows) do
-      tx_ctx.add_op(api.convert_line_to_todo, row)
-    end
-    for _, row in ipairs(insert_rows) do
-      tx_ctx.add_op(api.insert_new_todo_below, row)
-    end
+  transaction.run(bufnr, function(tx_ctx)
+    tx_ctx.add_op(api.create_todos, start_row, end_row, is_visual)
   end, function()
     require("checkmate.highlights").apply_highlighting(bufnr)
   end)

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -419,7 +419,6 @@ end
 ---@return boolean success
 function M.create()
   local api = require("checkmate.api")
-  local parser = require("checkmate.parser")
   local transaction = require("checkmate.transaction")
   local util = require("checkmate.util")
 
@@ -439,7 +438,7 @@ function M.create()
 
   local start_row, end_row
   if is_visual then
-    vim.cmd([[normal! <Esc>]])
+    vim.cmd([[execute "normal! \<Esc>"]])
     -- get the sel start/end row (1-based)
     local mark_start = vim.api.nvim_buf_get_mark(bufnr, "<")
     local mark_end = vim.api.nvim_buf_get_mark(bufnr, ">")
@@ -455,7 +454,7 @@ function M.create()
     end_row = start_row
   end
 
-  if not start_row or not end_row then
+  if start_row == nil or end_row == nil then
     return false
   end
 

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -38,8 +38,8 @@ local api = require("checkmate.api")
 ---the exposed transaction state is referred to as "context"
 ---the internal state is M._state
 ---@class checkmate.TransactionContext
----@field get_todo_by_id function(id: integer): checkmate.TodoItem
----@field get_todo_by_row function(row: integer): checkmate.TodoItem
+---@field get_todo_by_id function(id: integer): checkmate.TodoItem?
+---@field get_todo_by_row function(row: integer): checkmate.TodoItem?
 ---@field add_op function(fn: fn, ...)
 ---@field add_cb function(fn: fn, ...)
 ---@field get_buf function(): integer Returns the buffer
@@ -79,19 +79,16 @@ function M.run(bufnr, entry_fn, post_fn)
   state.context = {
     -- Get the current (latest) todo item by ID
     get_todo_by_id = function(extmark_id)
-      local item = M._state.todo_map[extmark_id]
-      if not item then
-        vim.notify("Could not find todo by id: " .. extmark_id)
-      end
       return M._state.todo_map[extmark_id]
     end,
 
     get_todo_by_row = function(row)
-      local item =
-        require("checkmate.parser").get_todo_item_at_position(M._state.bufnr, row, 0, { todo_map = M._state.todo_map })
-      if not item then
-        vim.notify("Could not find todo by row: " .. row)
-      end
+      return require("checkmate.parser").get_todo_item_at_position(
+        M._state.bufnr,
+        row,
+        0,
+        { todo_map = M._state.todo_map }
+      )
     end,
 
     --- Queue any function and its arguments

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -142,8 +142,8 @@ describe("API", function()
       local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
-      local checked = config.options.todo_markers.checked
+      local unchecked = config.get_defaults().todo_markers.unchecked
+      local checked = config.get_defaults().todo_markers.checked
 
       assert.matches("- " .. vim.pesc(unchecked) .. " Unchecked task", lines[3])
       assert.matches("- " .. vim.pesc(checked) .. " Checked task", lines[4])
@@ -346,8 +346,8 @@ describe("API", function()
   describe("todo creation", function()
     it("should convert a regular line to a todo item", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
-      local default_list_marker = config.options.default_list_marker
+      local unchecked = config.get_defaults().todo_markers.unchecked
+      local default_list_marker = config.get_defaults().default_list_marker
 
       local file_path = h.create_temp_file()
       local content = "# Todo List\n\nThis is a regular line\n"
@@ -369,7 +369,7 @@ describe("API", function()
 
     it("should convert a line with existing list marker to todo", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
+      local unchecked = config.get_defaults().todo_markers.unchecked
 
       local file_path = h.create_temp_file()
       local content = [[
@@ -404,8 +404,8 @@ describe("API", function()
 
     it("should insert a new todo below when cursor is on existing todo", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
-      local default_list_marker = config.options.default_list_marker
+      local unchecked = config.get_defaults().todo_markers.unchecked
+      local default_list_marker = config.get_defaults().default_list_marker
 
       local file_path = h.create_temp_file()
       local content = [[
@@ -432,8 +432,8 @@ Some other content
 
     it("should maintain indentation when inserting new todo", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
-      local default_list_marker = config.options.default_list_marker
+      local unchecked = config.get_defaults().todo_markers.unchecked
+      local default_list_marker = config.get_defaults().default_list_marker
 
       local file_path = h.create_temp_file()
       local content = [[
@@ -457,7 +457,7 @@ Some other content ]]
 
     it("should increment ordered list numbers when inserting", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
+      local unchecked = config.get_defaults().todo_markers.unchecked
 
       local file_path = h.create_temp_file()
       local content = [[
@@ -483,8 +483,8 @@ Some other content ]]
 
     it("should handle empty lines correctly", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
-      local default_list_marker = config.options.default_list_marker
+      local unchecked = config.get_defaults().todo_markers.unchecked
+      local default_list_marker = config.get_defaults().default_list_marker
 
       local file_path = h.create_temp_file()
       local content = [[
@@ -509,8 +509,8 @@ Some other content ]]
 
     it("should convert multiple selected lines to todos", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
-      local default_list_marker = config.options.default_list_marker
+      local unchecked = config.get_defaults().todo_markers.unchecked
+      local default_list_marker = config.get_defaults().default_list_marker
 
       local file_path = h.create_temp_file()
       local content = [[
@@ -540,7 +540,7 @@ Line 2
   describe("todo manipulation", function()
     it("should add metadata to todo items", function()
       local config = require("checkmate.config")
-      local unchecked = config.options.todo_markers.unchecked
+      local unchecked = config.get_defaults().todo_markers.unchecked
 
       local file_path = h.create_temp_file()
 
@@ -719,8 +719,8 @@ Line 2
 
       local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-      local checked = config.options.todo_markers.checked
-      local unchecked = config.options.todo_markers.unchecked
+      local checked = config.get_defaults().todo_markers.checked
+      local unchecked = config.get_defaults().todo_markers.unchecked
 
       assert.matches("- " .. vim.pesc(checked) .. " Task 1", lines[3])
       assert.matches("- " .. vim.pesc(unchecked) .. " Task 2 @priority%(high%)", lines[4])
@@ -1578,8 +1578,8 @@ Normal content line (not a todo)]]
 
       -- no archive section should have been created
       local archive_heading_string = require("checkmate.util").get_heading_string(
-        config.options.archive.heading.title,
-        config.options.archive.heading.level
+        config.get_defaults().archive.heading.title,
+        config.get_defaults().archive.heading.level
       )
       assert.no.matches(vim.pesc(archive_heading_string), buffer_content)
 
@@ -1635,7 +1635,7 @@ Some content here
       local buffer_content = table.concat(lines, "\n")
 
       local archive_heading_string =
-        require("checkmate.util").get_heading_string(heading_title, config.options.archive.heading.level)
+        require("checkmate.util").get_heading_string(heading_title, config.get_defaults().archive.heading.level)
 
       local main_section = buffer_content:match("^(.-)" .. archive_heading_string)
 
@@ -1711,8 +1711,8 @@ Some content here
       local buffer_content = table.concat(lines, "\n")
 
       local archive_heading_string = require("checkmate.util").get_heading_string(
-        vim.pesc(config.options.archive.heading.title),
-        config.options.archive.heading.level
+        vim.pesc(config.get_defaults().archive.heading.title),
+        config.get_defaults().archive.heading.level
       )
 
       local main_section = buffer_content:match("^(.-)" .. archive_heading_string)

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -487,15 +487,20 @@ Some other content ]]
       local default_list_marker = config.options.default_list_marker
 
       local file_path = h.create_temp_file()
-      local content = "\n\n"
+      local content = [[
+- Todo1
+
+  - Child1]]
       local bufnr = setup_todo_buffer(file_path, content)
 
-      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
       local success = require("checkmate").create()
       assert.is_true(success)
 
       local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-      assert.equal(default_list_marker .. " " .. unchecked .. " ", lines[1])
+      assert.equal("- Todo1", lines[1])
+      assert.equal(default_list_marker .. " " .. unchecked .. " ", lines[2])
+      assert.equal("  - Child1", lines[3])
 
       finally(function()
         h.cleanup_buffer(bufnr, file_path)

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -508,7 +508,10 @@ Some other content ]]
       local default_list_marker = config.options.default_list_marker
 
       local file_path = h.create_temp_file()
-      local content = "Line 1\nLine 2\nLine 3\n"
+      local content = [[
+Line 1
+Line 2
+  - Line 3]]
       local bufnr = setup_todo_buffer(file_path, content)
 
       -- select all lines
@@ -520,7 +523,8 @@ Some other content ]]
       local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
       assert.equal(default_list_marker .. " " .. unchecked .. " Line 1", lines[1])
       assert.equal(default_list_marker .. " " .. unchecked .. " Line 2", lines[2])
-      assert.equal(default_list_marker .. " " .. unchecked .. " Line 3", lines[3])
+      assert.equal("  " .. default_list_marker .. " " .. unchecked .. " Line 3", lines[3]) -- preserves indentation
+      assert.equal(3, #lines) -- ensure no new line created
 
       finally(function()
         h.cleanup_buffer(bufnr, file_path)


### PR DESCRIPTION
- In **_normal_** mode:
  - Will convert a line under the cursor to a todo item if it is not one
  - Will append a new todo item below the current line, making a sibling todo item, that attempts to match the list marker and indentation
  - If an ordered list marker, will attempt to auto-increment
- In **_visual_** mode:
  - Will convert each line in the selection to a new todo item with the default list marker
  - Will ignore existing todo items (first line only). If the todo item spans more than one line, the
   additional lines will be converted to individual todos
  - Will not append any new todo items even if all lines in the selection are already todo items
- Maintains `enter_insert_after_new` functionality
- Works correctly on empty/blank lines
- Technically, no breaking changes to the public API interface, though the behavior of 'create' is different
