### PR TITLE
Fix/allow multi char todo markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ Enhance your todos with custom [metadata](#metadata) with quick keymaps!
 
 -----------------------------------------------------
 
+--- The text string used for todo markers is expected to be 1 character length.
+--- Multiple characters _may_ work but are not currently supported and could lead to unexpected results.
 ---@class checkmate.TodoMarkers
 ---Character used for unchecked items
 ---@field unchecked string
@@ -561,6 +563,9 @@ opts = {
     }
 }
 ```
+
+> [!WARN]
+> Multi-character todo markers are not currently supported but _may_ work. For consistent behavior, recommend using a single character.
 
 ## Metadata
 

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -137,6 +137,8 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 
 -----------------------------------------------------
 
+--- The text string used for todo markers is expected to be 1 character length.
+--- Multiple characters _may_ work but are not currently supported and could lead to unexpected results.
 ---@class checkmate.TodoMarkers
 ---Character used for unchecked items
 ---@field unchecked string
@@ -538,12 +540,14 @@ function M.validate_options(opts)
     end
 
     -- Ensure the todo_markers are only 1 character length
-    if opts.todo_markers.checked and vim.fn.strcharlen(opts.todo_markers.checked) ~= 1 then
+    -- NOTE: Decided not to implement yet. Have added WARNING to config documentation
+    --
+    --[[ if opts.todo_markers.checked and vim.fn.strcharlen(opts.todo_markers.checked) ~= 1 then
       return false, "The 'checked' todo marker must be a single character"
     end
     if opts.todo_markers.unchecked and vim.fn.strcharlen(opts.todo_markers.unchecked) ~= 1 then
       return false, "The 'unchecked' todo marker must be a single character"
-    end
+    end ]]
   end
 
   -- Validate default_list_marker

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -69,13 +69,6 @@ describe("checkmate init and lifecycle", function()
       assert.is_false(result)
       assert.is_false(checkmate.is_running())
 
-      -- Reset and try with invalid todo marker length
-      _G.reset_state()
-      ---@diagnostic disable-next-line: missing-fields, assign-type-mismatch
-      result = checkmate.setup({ todo_markers = { checked = "too long" } })
-      assert.is_false(result)
-      assert.is_false(checkmate.is_running())
-
       checkmate.stop()
     end)
 


### PR DESCRIPTION
Reverses earlier commit to disallow multi-character todo markers. Rather than intentionally breaking this for now, will add documentation to warn user of unexpected results.