### PR TITLE
fix(config)!: no longer apply default metadata props to a modified default metadata in config

### DIFF
--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -887,6 +887,12 @@ function M.setup(opts)
       end
 
       config = vim.tbl_deep_extend("force", config, opts)
+
+      if opts.metadata then
+        for meta_name, meta_props in pairs(opts.metadata) do
+          config.metadata[meta_name] = vim.deepcopy(meta_props)
+        end
+      end
     end
 
     -- save user style for colorscheme updates

--- a/tests/checkmate/config_spec.lua
+++ b/tests/checkmate/config_spec.lua
@@ -104,7 +104,7 @@ describe("Config", function()
         theme.generate_style_defaults:revert()
       end)
 
-      it("fills in missing nested keys but keeps user-supplied values", function()
+      it("fills in missing style but keeps user-supplied values", function()
         local checkmate = require("checkmate")
         local config = require("checkmate.config")
 
@@ -132,7 +132,7 @@ describe("Config", function()
         checkmate.stop()
       end)
 
-      it("never overwrites an explicit user value on back-fill", function()
+      it("never overwrites an explicit user value on style back-fill", function()
         local checkmate = require("checkmate")
         local config = require("checkmate.config")
 
@@ -176,6 +176,28 @@ describe("Config", function()
     it("should successfully validate default options", function()
       local config = require("checkmate.config")
       assert.is_true(config.validate_options(config.get_defaults()))
+    end)
+
+    it("should allow user to redefine a default metadata entry while keeping other defaults", function()
+      local checkmate = require("checkmate")
+      ---@diagnostic disable-next-line: missing-fields
+      checkmate.setup({
+        metadata = {
+          ---@diagnostic disable-next-line: missing-fields
+          done = {
+            key = "test",
+          },
+        },
+      })
+
+      local config = require("checkmate.config")
+
+      assert.equal(vim.tbl_count(config.options.metadata.done), 1)
+      assert.equal(config.options.metadata.done.key, "test")
+
+      assert.same(config.options.metadata.started, config.get_defaults().metadata.started)
+
+      checkmate.stop()
     end)
   end)
 end)


### PR DESCRIPTION
E.g., this allows the user to modify the default @done metadata but not have the default props for this metadata merged in. If the rest of the default behavior is desired, the config can be copied from the documentation.

this **could break** user config's that have been relying on the defaults to merge in

### Why
When a user defines a metadata entry, they should have full control over it's definition. Unexpected behavior can occur when defaults are still merged into the final metadata definition. If the user should want to use _most_ of the default metadata definition but make a modification, they should copy the full definition from the documentation/examples.

For example, consider a user's config such as
```lua
opts = {
  metadata = {
    done = {
      key = "<leader>Tf"  -- user wants to change one field in the default `@done` definition
    }
  }
}
```
#### Previous behavior:
This would merge with the rest of the config.metadata.done default table:
```lua
done = {
  aliases = { "completed", "finished" },
  style = { fg = "#96de7a" },
  get_value = function()
    return tostring(os.date("%m/%d/%y %H:%M"))
  end,
  key = "<leader>Tf", -- modified
  on_add = function(todo_item)
    require("checkmate").set_todo_item(todo_item, "checked")
  end,
  on_remove = function(todo_item)
    require("checkmate").set_todo_item(todo_item, "unchecked")
  end,
  sort_order = 30,
},

```

#### New behavior:
```lua
done = {
  key = "<leader>Tf", -- modified
},
```
No other fields are present as they were not defined by the user.