### PR TITLE
fix(api): fixes bug with TSBufDisable call with nvim-treesitter update #106

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,14 @@ Enhance your todos with custom [metadata](#metadata) with quick keymaps!
 ---will be merged with defaults.
 ---@field metadata checkmate.Metadata
 ---
----Settings for the archived todos section
----@field archive checkmate.ArchiveSettings?
+---@field archive checkmate.ArchiveSettings? -- Settings for the archived todos section
 ---
 ---Config for the linter
 ---@field linter checkmate.LinterConfig?
+---
+---Turn off treesitter highlights (on by default)
+---See `:h treesitter-highlight`
+---@field disable_ts_highlights? boolean
 
 -----------------------------------------------------
 

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -82,11 +82,11 @@ function M.setup_buffer(bufnr)
   local highlights = require("checkmate.highlights")
   highlights.apply_highlighting(bufnr, { debug_reason = "API setup" })
 
-  local has_nvim_treesitter, _ = pcall(require, "nvim-treesitter")
-  if has_nvim_treesitter then
-    vim.cmd("TSBufDisable highlight")
-  else
-    vim.api.nvim_set_option_value("syntax", "OFF", { buf = bufnr })
+  vim.api.nvim_set_option_value("syntax", "OFF", { buf = bufnr })
+
+  -- User can opt out of TS highlighting if desired
+  if config.options.disable_ts_highlights == true then
+    vim.treesitter.stop(bufnr)
   end
 
   M.setup_keymaps(bufnr)

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -104,10 +104,16 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---will be merged with defaults.
 ---@field metadata checkmate.Metadata
 ---
----@field archive checkmate.ArchiveSettings? -- Settings for the archived todos section
+---Settings for the archived todos section
+---@field archive checkmate.ArchiveSettings?
 ---
 ---Config for the linter
 ---@field linter checkmate.LinterConfig?
+---
+---Turn off treesitter highlights (on by default)
+---Buffer local
+---See `:h treesitter-highlight`
+---@field disable_ts_highlights? boolean
 
 -----------------------------------------------------
 


### PR DESCRIPTION
Breaking changes to nvim-treesitter but this plugin is not a dependency for checkmate.nvim