### PR TITLE
fix(parser): fixes incorrect parsing of metadata tags and values

### DIFF
--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -1362,7 +1362,7 @@ function M.rebuild_line_with_sorted_metadata(line, metadata)
   local log = require("checkmate.log")
 
   -- remove all metadata tags but preserve all other content including whitespace
-  local content_without_metadata = line:gsub("@%w+%([^)]*%)", "")
+  local content_without_metadata = line:gsub("@[%a][%w_%-]*%b()", "")
 
   -- remove trailing whitespace but keep all indentation
   content_without_metadata = content_without_metadata:gsub("%s+$", "")
@@ -1373,7 +1373,6 @@ function M.rebuild_line_with_sorted_metadata(line, metadata)
 
   local sorted_entries = M.sort_metadata_entries(metadata.entries)
 
-  -- Rebuild the line with content and sorted metadata
   local result_line = content_without_metadata
 
   -- add back each metadata tag in sorted order

--- a/tests/checkmate/parser_spec.lua
+++ b/tests/checkmate/parser_spec.lua
@@ -629,6 +629,18 @@ Line that should not affect parent-child relationship
       assert.same(metadata.entries[3], metadata.by_tag.tags)
     end)
 
+    it("should not malformed metadata", function()
+      local parser = require("checkmate.parser")
+
+      -- space between @tag and ()
+      local line = "- □ Task @tag (value)"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equal(0, #metadata.entries)
+    end)
+
     it("should handle metadata with spaces in values", function()
       local parser = require("checkmate.parser")
       local line = "- □ Task @note(this is a note with spaces)"
@@ -650,7 +662,19 @@ Line that should not affect parent-child relationship
 
       assert.equal(1, #metadata.entries)
       assert.equal("note", metadata.entries[1].tag)
-      assert.equal("spaced value", metadata.entries[1].value) -- Spaces should be trimmed
+      assert.equal("spaced value", metadata.entries[1].value)
+    end)
+
+    it("should handle metadata with parentheses in value", function()
+      local parser = require("checkmate.parser")
+      local line = "- □ Task @issue(fix(api))"
+      local row = 0
+
+      local metadata = parser.extract_metadata(line, row)
+
+      assert.equal(1, #metadata.entries)
+      assert.equal("issue", metadata.entries[1].tag)
+      assert.equal("fix(api)", metadata.entries[1].value)
     end)
 
     it("should properly track position_in_line", function()


### PR DESCRIPTION
Should not parse malformed @tag(value)

Should correctly parse complex values, e.g. with nested parentheses