### PR TITLE
Feat/metadata upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,15 @@ Enhance your todos with custom [metadata](#metadata) with quick keymaps!
 #### User commands
 `:Checkmate [subcommand]`
 
-| subcommand | Description |
-|------------|-------------|
+| subcommand   | Description |
+|--------------|-------------|
 | `archive` | Archive all checked todo items in the buffer. See api `archive()` |
 | `check` | Mark the todo item under the cursor as checked. See api `check()`|
 | `create` | Create a new todo item at the current line or line below if a todo already exists. In visual mode, convert each line to a todo item. See api `create()`|
 | `lint` | Lint this buffer for Checkmate formatting issues. See api `lint()` |
 | `metadata add` | Add a metadata tag to the todo under the cursor or within the selection. Usage: `:Checkmate metadata add <key> [value]`. See api `add_metadata(key, value)` |
 | `metadata remove` | Remove a specific metadata tag from the todo under the cursor or within the selection. Usage: `:Checkmate metadata remove <key>`. See api `remove_metadata(key)` |
+| `metadata select_value` | Select a value from the 'choices' option for the metadata tag under the cursor. See api `select_metadata_value()` |
 | `metadata toggle` | Toggle a metadata tag on/off for the todo under the cursor or within the selection. Usage: `:Checkmate metadata toggle <key> [value]`. See api `toggle_metadata(key, value)` |
 | `remove_all_metadata` | Remove *all* metadata tags from the todo under the cursor or within the selection. See api `remove_all_metadata()` |
 | `toggle` | Toggle the todo item under the cursor (normal mode) or all todo items within the selection (visual mode). See api `toggle()` |
@@ -213,6 +214,8 @@ CheckmateLint
 ---Default list item marker to be used when creating new Todo items
 ---@field default_list_marker "-" | "*" | "+"
 ---
+---@field ui? checkmate.UISettings
+---
 ---Highlight settings (override merge with defaults)
 ---Default style will attempt to integrate with current colorscheme (experimental)
 ---May need to tweak some colors to your liking
@@ -225,7 +228,7 @@ CheckmateLint
 --- 2 = toggle triggered when cursor/selection includes any 2nd level children of todo item
 ---@field todo_action_depth integer
 ---
----Enter insert mode after `:CheckmateCreate`, require("checkmate").create()
+---Enter insert mode after `:Checkmate create`, require("checkmate").create()
 ---@field enter_insert_after_new boolean
 ---
 ---Options for smart toggle behavior
@@ -253,27 +256,28 @@ CheckmateLint
 ---@field todo_count_recursive boolean
 ---
 ---Whether to register keymappings defined in each metadata definition. If set the false,
----metadata actions (insert/remove) would need to be called programatically or otherwise mapped manually
+---metadata actions need to be called programatically or otherwise mapped manually
 ---@field use_metadata_keymaps boolean
 ---
 ---Custom @tag(value) fields that can be toggled on todo items
----To add custom metadata tag, simply add a field and props to this metadata table and it
----will be merged with defaults.
+---To add custom metadata tag, add a new field to this table with the metadata properties
 ---@field metadata checkmate.Metadata
 ---
----@field archive checkmate.ArchiveSettings? -- Settings for the archived todos section
+---Settings for the archived todos section
+---@field archive checkmate.ArchiveSettings?
 ---
 ---Config for the linter
 ---@field linter checkmate.LinterConfig?
 ---
 ---Turn off treesitter highlights (on by default)
+---Buffer local
 ---See `:h treesitter-highlight`
 ---@field disable_ts_highlights? boolean
 
 -----------------------------------------------------
 
 ---Actions that can be used for keymaps in the `keys` table of 'checkmate.Config'
----@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive"
+---@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive" | "select_metadata_value"
 
 ---Options for todo count indicator position
 ---@alias checkmate.TodoCountPosition "eol" | "inline"
@@ -285,7 +289,6 @@ CheckmateLint
 ---@field level ("trace" | "debug" | "info" | "warn" | "error" | "fatal" | vim.log.levels.DEBUG | vim.log.levels.ERROR | vim.log.levels.INFO | vim.log.levels.TRACE | vim.log.levels.WARN)?
 ---
 --- Should print log output to a file
---- Open with `:Checkmate debug_file`
 ---@field use_file boolean
 ---
 --- The default path on-disk where log files will be written to.
@@ -293,7 +296,7 @@ CheckmateLint
 ---@field file_path string?
 ---
 --- Should print log output to a scratch buffer
---- Open with `require("checkmate").debug_log()`
+--- Open with `:Checkate debug log` or `require("checkmate").debug_log()`
 ---@field use_buffer boolean
 
 -----------------------------------------------------
@@ -309,7 +312,16 @@ CheckmateLint
 
 -----------------------------------------------------
 
+---@class checkmate.UISettings
+---
+---Default behavior: attempt to use an installed plugin, if found
+---If false, will default to vim.ui.select
+---@field preferred_picker? "telescope" | "snacks" | "mini" | false
+
+-----------------------------------------------------
+
 ---@class checkmate.SmartToggleSettings
+---
 ---Whether to enable smart toggle behavior
 ---Default: true
 ---@field enabled boolean?
@@ -388,47 +400,63 @@ CheckmateLint
 ---@field todo_count_indicator vim.api.keyset.highlight?
 
 -----------------------------------------------------
+--- Metadata
 
 ---A table of canonical metadata tag names and associated properties that define the look and function of the tag
+---
+---A 'canonical' name is the main lookup name for a metadata tag; additional 'aliases' can be used that point to this name
 ---@alias checkmate.Metadata table<string, checkmate.MetadataProps>
 
 ---@class checkmate.MetadataProps
 ---Additional string values that can be used interchangably with the canonical tag name.
 ---E.g. @started could have aliases of `{"initiated", "began"}` so that @initiated and @began could
 ---also be used and have the same styling/functionality
----@field aliases string[]?
+---@field aliases? string[]
 ---
----Highlight settings or function that returns highlight settings based on the metadata's current value
----@field style vim.api.keyset.highlight|fun(value:string):vim.api.keyset.highlight
+---@alias checkmate.StyleFn
+---| fun(value: string):vim.api.keyset.highlight -- Legacy (to be removed in future release)
+---| fun(context?: checkmate.MetadataContext):vim.api.keyset.highlight
+---
+---Highlight settings table, or a function that returns highlight settings (being passed metadata context)
+---@field style? vim.api.keyset.highlight|checkmate.StyleFn
 ---
 ---Function that returns the default value for this metadata tag
----@field get_value fun():string
+---i.e. what is used after insertion
+---@field get_value? fun():string?|fun(context?: checkmate.MetadataContext):string
+---
+---@alias checkmate.ChoicesFn fun(context?: checkmate.MetadataContext, cb?: fun(items: string[])): string[]?
+---
+---Values that are populated during completion or select pickers
+---Can be either:
+--- - An array of items (string[])
+--- - A function that returns items
+---@field choices? string[]|checkmate.ChoicesFn
 ---
 ---Keymapping for toggling this metadata tag
----@field key string?
+---@field key? string
 ---
 ---Used for displaying metadata in a consistent order
----@field sort_order integer?
+---@field sort_order? integer
 ---
 ---Moves the cursor to the metadata after it is inserted
 ---  - "tag" - moves to the beginning of the tag
 ---  - "value" - moves to the beginning of the value
 ---  - false - disables jump (default)
----@field jump_to_on_insert "tag" | "value" | false?
+---@field jump_to_on_insert? "tag" | "value" | false
 ---
 ---Selects metadata text in visual mode after metadata is inserted
 ---The `jump_to_on_insert` field must be set (not false)
 ---The selected text will be the tag or value, based on jump_to_on_insert setting
 ---Default (false) - off
----@field select_on_insert boolean?
+---@field select_on_insert? boolean
 ---
 ---Callback to run when this metadata tag is added to a todo item
 ---E.g. can be used to change the todo item state
----@field on_add fun(todo_item: checkmate.TodoItem)?
+---@field on_add? fun(todo_item: checkmate.TodoItem)
 ---
 ---Callback to run when this metadata tag is removed from a todo item
 ---E.g. can be used to change the todo item state
----@field on_remove fun(todo_item: checkmate.TodoItem)?
+---@field on_remove? fun(todo_item: checkmate.TodoItem)
 
 -----------------------------------------------------
 
@@ -478,7 +506,7 @@ CheckmateLint
 ### Defaults
 ```lua
 ---@type checkmate.Config
-local _DEFAULTS = {
+local defaults = {
   enabled = true,
   notify = true,
   -- Default file matching:
@@ -506,13 +534,14 @@ local _DEFAULTS = {
     ["<leader>Tn"] = "create", -- Create todo item
     ["<leader>TR"] = "remove_all_metadata", -- Remove all metadata from a todo item
     ["<leader>Ta"] = "archive", -- Archive checked/completed todo items (move to bottom section)
+    ["<leader>Tv"] = "select_metadata_value", -- Update the value of a metadata tag under the cursor
   },
   default_list_marker = "-",
   todo_markers = {
     unchecked = "□",
     checked = "✔",
   },
-  style = {},
+  style = {}, -- override defaults
   todo_action_depth = 1, --  Depth within a todo item's hierachy from which actions (e.g. toggle) will act on the parent todo item
   enter_insert_after_new = true, -- Should enter INSERT mode after :CheckmateCreate (new todo)
   smart_toggle = {
@@ -529,8 +558,8 @@ local _DEFAULTS = {
   metadata = {
     -- Example: A @priority tag that has dynamic color based on the priority value
     priority = {
-      style = function(_value)
-        local value = _value:lower()
+      style = function(context)
+        local value = context.value:lower()
         if value == "high" then
           return { fg = "#ff5555", bold = true }
         elseif value == "medium" then
@@ -543,6 +572,9 @@ local _DEFAULTS = {
       end,
       get_value = function()
         return "medium" -- Default priority
+      end,
+      choices = function()
+        return { "low", "medium", "high" }
       end,
       key = "<leader>Tp",
       sort_order = 10,
@@ -582,7 +614,7 @@ local _DEFAULTS = {
       level = 2, -- e.g. ##
     },
     parent_spacing = 0, -- no extra lines between archived todos
-    newest_first = true
+    newest_first = true,
   },
   linter = {
     enabled = true,
@@ -620,52 +652,8 @@ Metadata tags allow you to add custom `@tag(value)` annotations to todo items.
   - `@done` - default value is the current date/time
   - `@priority` - "low" | "medium" (default) | "high"
 
-#### @priority example
 
-```lua
-priority = {
-  -- Dynamic styling based on the tag's current value
-  style = function(value)
-    local value = value:lower()
-    if value == "high" then
-      return { fg = "#ff5555", bold = true }
-    elseif value == "medium" then
-      return { fg = "#ffb86c" }
-    elseif value == "low" then
-      return { fg = "#8be9fd" }
-    else -- fallback
-      return { fg = "#8be9fd" }
-    end
-  end,
-  get_value = function() return "medium" end,  -- Default value
-  key = "<leader>Tp",                          -- Keymap to toggle
-  sort_order = 10,                             -- Order when multiple tags exist (lower comes first)
-  jump_to_on_insert = "value",                 -- Move the cursor after insertion
-  select_on_insert = true                      -- Select the 'value' (visual mode) on insert
-},
-```
-
-#### @done example
-
-```lua
-done = {
-  aliases = { "completed", "finished" },
-  style = { fg = "#96de7a" },
-  get_value = function()
-    return tostring(os.date("%m/%d/%y %H:%M"))
-  end,
-  key = "<leader>Td",
-  -- Changes todo state when tag is added
-  on_add = function(todo_item)
-    require("checkmate").set_todo_item(todo_item, "checked")
-  end,
-  -- Changes todo state when tag is removed
-  on_remove = function(todo_item)
-    require("checkmate").set_todo_item(todo_item, "unchecked")
-  end,
-  sort_order = 30,
-},
-```
+For how-tos and recipes for custom metadata, see the [Wiki](https://github.com/bngarren/checkmate.nvim/wiki/Todo-Metadata) page.
 
 ## Todo count indicator
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Markdown-based todo list plugin for Neovim with a nice UI and full customizati
 - Smart toggling behavior
 - Archive completed todos
 
-> !IMPORTANT
+> [!IMPORTANT]
 > Check out the newly upgraded metadata features introduced in v0.9.0.
 > These include more powerful metadata definitions/custmomization, a metadata value picker, and jump commands. See the [Wiki](https://github.com/bngarren/checkmate.nvim/wiki/Metadata) for in-depth guide and recipes!
 
@@ -82,12 +82,11 @@ Checkmate automatically activates when you open a Markdown file that matches you
 
 <br>
 
-> [!TIP]
-> You can customize which files activate Checkmate using the `files` configuration option:
-> ```lua
-> files = { "tasks", "*.plan", "project/**/todo.md" }
-> ```
-> Patterns support full Unix-style globs including `*`, `**`, `?`, `[abc]`, and `{foo,bar}`
+You can customize **which files activate Checkmate** using the `files` configuration option:
+```lua
+files = { "tasks", "*.plan", "project/**/todo.md" }
+```
+Patterns support full Unix-style globs including `*`, `**`, `?`, `[abc]`, and `{foo,bar}`
 
 ### 2. Create Todo Items
 
@@ -111,8 +110,7 @@ Checkmate automatically activates when you open a Markdown file that matches you
 
 Enhance your todos with custom [metadata](#metadata) with quick keymaps!
 
-> [!NOTE]
-> The Checkmate buffer is saved as regular Markdown!
+The Checkmate buffer is **saved as regular Markdown** which means it's compatible with any Markdown editor!
 
 # ☑️ Commands
 > [!WARNING]
@@ -128,6 +126,8 @@ Enhance your todos with custom [metadata](#metadata) with quick keymaps!
 | `create` | Create a new todo item at the current line or line below if a todo already exists. In visual mode, convert each line to a todo item. See api `create()`|
 | `lint` | Lint this buffer for Checkmate formatting issues. See api `lint()` |
 | `metadata add` | Add a metadata tag to the todo under the cursor or within the selection. Usage: `:Checkmate metadata add <key> [value]`. See api `add_metadata(key, value)` |
+| `metadata jump_next` | Move the cursor to the next metadata tag for the todo item under the cursor. See api `jump_next_metadata()` |
+| `metadata jump_previous` | Move the cursor to the previous metadata tag for the todo item under the cursor. See api `jump_previous_metadata()` |
 | `metadata remove` | Remove a specific metadata tag from the todo under the cursor or within the selection. Usage: `:Checkmate metadata remove <key>`. See api `remove_metadata(key)` |
 | `metadata select_value` | Select a value from the 'choices' option for the metadata tag under the cursor. See api `select_metadata_value()` |
 | `metadata toggle` | Toggle a metadata tag on/off for the todo under the cursor or within the selection. Usage: `:Checkmate metadata toggle <key> [value]`. See api `toggle_metadata(key, value)` |
@@ -668,7 +668,7 @@ Metadata tags allow you to add custom `@tag(value)` annotations to todo items.
   - `@priority` - "low" | "medium" (default) | "high"
 
 
-For how-tos and recipes for custom metadata, see the [Wiki](https://github.com/bngarren/checkmate.nvim/wiki/Todo-Metadata) page.
+For in-depth guide and recipes for custom metadata, see the [Wiki](https://github.com/bngarren/checkmate.nvim/wiki/Todo-Metadata) page.
 
 ## Todo count indicator
 
@@ -751,7 +751,7 @@ opts = {
 # Archiving
 Allows you to easily reorganize the buffer by moving all checked/completed todo items to a Markdown section beneath all other content. The unchecked todos are reorganized up top and spacing is adjusted.
 
-See `CheckmateArchive` command or `require("checkmate").archive()`
+See `Checkmate archive` command or `require("checkmate").archive()`
 
 > Current behavior (could be adjusted in the future): a checked todo item that is nested under an unchecked parent will not be archived. This prevents 'orphan' todos being separated from their parents. Similarly, a checked parent todo will carry all nested todos (checked and unchecked) when archived.
 
@@ -837,7 +837,7 @@ Planned features:
 
 - [x] **Archiving** - manually or automatically move completed items to the bottom of the document. _Added v0.7.0_ (experimental)
 
-- [x] Smart toggling - toggle all children checked if a parent todo is checked. Toggle a parent checked if the last unchecked child is checked. _Added v0.7.0_ 
+- [x] **Smart toggling** - toggle all children checked if a parent todo is checked. Toggle a parent checked if the last unchecked child is checked. _Added v0.7.0_ 
 
 - [ ] Sorting API - user can register custom sorting functions and keymap them so that sibling todo items can be reordered quickly. e.g. `function(todo_a, todo_b)` should return an integer, and where todo_a/todo_b is a table containing data such as checked state and metadata tag/values
 

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -1072,13 +1072,8 @@ function M.add_metadata(ctx, operations)
     end
 
     -- get value with fallback to get_value()
-    local meta_value = op.meta_value
-    if not meta_value and meta_props.get_value then
-      local context = meta_module.create_context(item, op.meta_name, "", bufnr)
-      meta_value = meta_props.get_value(context)
-      meta_value = meta_value:gsub("^%s+", ""):gsub("%s+$", "")
-    end
-    meta_value = meta_value or ""
+    local context = meta_module.create_context(item, op.meta_name, "", bufnr)
+    local meta_value = op.meta_value or meta_module.evaluate_value(meta_props, context) or ""
 
     local item_hunks = M.compute_diff_add_metadata({ item }, op.meta_name, meta_value)
     vim.list_extend(hunks, item_hunks)

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -67,6 +67,14 @@ M.commands = {
     end,
     opts = { desc = "Identify Checkmate formatting issues" },
   },
+  {
+    name = "Select Metadata Value",
+    cmd = "CheckmateSelectMetadataValue",
+    func = function()
+      require("checkmate").select_metadata_value()
+    end,
+    opts = { desc = "Update the value in a metadata tag" },
+  },
 }
 
 -- Register all commands

--- a/lua/checkmate/commands_new.lua
+++ b/lua/checkmate/commands_new.lua
@@ -104,6 +104,13 @@ local top_commands = {
           return vim.tbl_keys(require("checkmate.config").options.metadata)
         end,
       },
+      select_value = {
+        desc = "Select a value from completion options for the metadata tag under the cursor",
+        nargs = "0",
+        handler = function()
+          require("checkmate").select_metadata_value()
+        end,
+      },
     },
   },
 

--- a/lua/checkmate/commands_new.lua
+++ b/lua/checkmate/commands_new.lua
@@ -111,6 +111,20 @@ local top_commands = {
           require("checkmate").select_metadata_value()
         end,
       },
+      jump_next = {
+        desc = "Move cursor to next metadata tag for todo under the cursor",
+        nargs = "0",
+        handler = function()
+          require("checkmate").jump_next_metadata()
+        end,
+      },
+      jump_previous = {
+        desc = "Move cursor to previous metadata tag for todo under the cursor",
+        nargs = "0",
+        handler = function()
+          require("checkmate").jump_previous_metadata()
+        end,
+      },
     },
   },
 

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -262,9 +262,11 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---Highlight settings table, or a function that returns highlight settings (being passed metadata context)
 ---@field style? vim.api.keyset.highlight|checkmate.StyleFn
 ---
+---@alias checkmate.GetValueFn fun(context?: checkmate.MetadataContext):string
+---
 ---Function that returns the default value for this metadata tag
 ---i.e. what is used after insertion
----@field get_value? fun():string?|fun(context?: checkmate.MetadataContext):string
+---@field get_value? checkmate.GetValueFn
 ---
 ---@alias checkmate.ChoicesFn fun(context?: checkmate.MetadataContext, cb?: fun(items: string[])): string[]?
 ---

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -301,6 +301,10 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---Callback to run when this metadata tag is removed from a todo item
 ---E.g. can be used to change the todo item state
 ---@field on_remove? fun(todo_item: checkmate.TodoItem)
+---
+---Callback to run when this metadata tag's value is changed (not on initial add)
+---Receives the todo item, old value, and new value
+---@field on_change? fun(todo_item: checkmate.TodoItem, old_value: string, new_value: string)
 
 -----------------------------------------------------
 
@@ -796,6 +800,7 @@ function M.validate_options(opts)
         { meta_props.sort_order, "number", "metadata." .. meta_name .. ".sort_order", true },
         { meta_props.on_add, "function", "metadata." .. meta_name .. ".on_add", true },
         { meta_props.on_remove, "function", "metadata." .. meta_name .. ".on_remove", true },
+        { meta_props.on_change, "function", "metadata." .. meta_name .. ".on_change", true },
         { meta_props.select_on_insert, "boolean", "metadata." .. meta_name .. ".select_on_insert", true },
       }
 

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -119,7 +119,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 -----------------------------------------------------
 
 ---Actions that can be used for keymaps in the `keys` table of 'checkmate.Config'
----@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive" | "select_metadata_value"
+---@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive" | "select_metadata_value" | "jump_next_metadata" | "jump_previous_metadata"
 
 ---Options for todo count indicator position
 ---@alias checkmate.TodoCountPosition "eol" | "inline"
@@ -376,6 +376,8 @@ local defaults = {
     ["<leader>TR"] = "remove_all_metadata", -- Remove all metadata from a todo item
     ["<leader>Ta"] = "archive", -- Archive checked/completed todo items (move to bottom section)
     ["<leader>Tv"] = "select_metadata_value", -- Update the value of a metadata tag under the cursor
+    ["<leader>T]"] = "jump_next_metadata", -- Move cursor to next metadata tag
+    ["<leader>T["] = "jump_previous_metadata", -- Move cursor to previous metadata tag
   },
   default_list_marker = "-",
   todo_markers = {

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -85,6 +85,8 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---Enable/disable the todo count indicator (shows number of sub-todo items completed)
 ---@field show_todo_count boolean
 ---
+---Options for todo count indicator position
+---@alias checkmate.TodoCountPosition "eol" | "inline"
 ---Position to show the todo count indicator (if enabled)
 --- `eol` = End of the todo item line
 --- `inline` = After the todo marker, before the todo item text
@@ -121,9 +123,6 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---Actions that can be used for keymaps in the `keys` table of 'checkmate.Config'
 ---@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive" | "select_metadata_value" | "jump_next_metadata" | "jump_previous_metadata"
 
----Options for todo count indicator position
----@alias checkmate.TodoCountPosition "eol" | "inline"
-
 -----------------------------------------------------
 
 ---@class checkmate.LogSettings
@@ -146,6 +145,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 --- The text string used for todo markers is expected to be 1 character length.
 --- Multiple characters _may_ work but are not currently supported and could lead to unexpected results.
 ---@class checkmate.TodoMarkers
+---
 ---Character used for unchecked items
 ---@field unchecked string
 ---
@@ -252,6 +252,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---@alias checkmate.Metadata table<string, checkmate.MetadataProps>
 
 ---@class checkmate.MetadataProps
+---
 ---Additional string values that can be used interchangably with the canonical tag name.
 ---E.g. @started could have aliases of `{"initiated", "began"}` so that @initiated and @began could
 ---also be used and have the same styling/functionality
@@ -278,7 +279,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 --- - A function that returns items
 ---@field choices? string[]|checkmate.ChoicesFn
 ---
----Keymapping for toggling this metadata tag
+---Keymapping for toggling (adding/removing) this metadata tag
 ---@field key? string
 ---
 ---Used for displaying metadata in a consistent order
@@ -304,7 +305,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---E.g. can be used to change the todo item state
 ---@field on_remove? fun(todo_item: checkmate.TodoItem)
 ---
----Callback to run when this metadata tag's value is changed (not on initial add)
+---Callback to run when this metadata tag's value is changed (not on initial add or removal)
 ---Receives the todo item, old value, and new value
 ---@field on_change? fun(todo_item: checkmate.TodoItem, old_value: string, new_value: string)
 

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -56,6 +56,8 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---Default list item marker to be used when creating new Todo items
 ---@field default_list_marker "-" | "*" | "+"
 ---
+---@field ui? checkmate.UISettings
+---
 ---Highlight settings (override merge with defaults)
 ---Default style will attempt to integrate with current colorscheme (experimental)
 ---May need to tweak some colors to your liking
@@ -68,7 +70,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 --- 2 = toggle triggered when cursor/selection includes any 2nd level children of todo item
 ---@field todo_action_depth integer
 ---
----Enter insert mode after `:CheckmateCreate`, require("checkmate").create()
+---Enter insert mode after `:Checkmate create`, require("checkmate").create()
 ---@field enter_insert_after_new boolean
 ---
 ---Options for smart toggle behavior
@@ -96,12 +98,11 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---@field todo_count_recursive boolean
 ---
 ---Whether to register keymappings defined in each metadata definition. If set the false,
----metadata actions (insert/remove) would need to be called programatically or otherwise mapped manually
+---metadata actions need to be called programatically or otherwise mapped manually
 ---@field use_metadata_keymaps boolean
 ---
 ---Custom @tag(value) fields that can be toggled on todo items
----To add custom metadata tag, simply add a field and props to this metadata table and it
----will be merged with defaults.
+---To add custom metadata tag, add a new field to this table with the metadata properties
 ---@field metadata checkmate.Metadata
 ---
 ---Settings for the archived todos section
@@ -118,7 +119,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 -----------------------------------------------------
 
 ---Actions that can be used for keymaps in the `keys` table of 'checkmate.Config'
----@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive"
+---@alias checkmate.Action "toggle" | "check" | "uncheck" | "create" | "remove_all_metadata" | "archive" | "select_metadata_value"
 
 ---Options for todo count indicator position
 ---@alias checkmate.TodoCountPosition "eol" | "inline"
@@ -130,7 +131,6 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---@field level ("trace" | "debug" | "info" | "warn" | "error" | "fatal" | vim.log.levels.DEBUG | vim.log.levels.ERROR | vim.log.levels.INFO | vim.log.levels.TRACE | vim.log.levels.WARN)?
 ---
 --- Should print log output to a file
---- Open with `:Checkmate debug_file`
 ---@field use_file boolean
 ---
 --- The default path on-disk where log files will be written to.
@@ -138,7 +138,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---@field file_path string?
 ---
 --- Should print log output to a scratch buffer
---- Open with `require("checkmate").debug_log()`
+--- Open with `:Checkate debug log` or `require("checkmate").debug_log()`
 ---@field use_buffer boolean
 
 -----------------------------------------------------
@@ -154,7 +154,16 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 
 -----------------------------------------------------
 
+---@class checkmate.UISettings
+---
+---Default behavior: attempt to use an installed plugin, if found
+---If false, will default to vim.ui.select
+---@field preferred_picker? "telescope" | "snacks" | "mini" | false
+
+-----------------------------------------------------
+
 ---@class checkmate.SmartToggleSettings
+---
 ---Whether to enable smart toggle behavior
 ---Default: true
 ---@field enabled boolean?
@@ -233,47 +242,63 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---@field todo_count_indicator vim.api.keyset.highlight?
 
 -----------------------------------------------------
+--- Metadata
 
 ---A table of canonical metadata tag names and associated properties that define the look and function of the tag
+---
+---A 'canonical' name is the main lookup name for a metadata tag; additional 'aliases' can be used that point to this name
 ---@alias checkmate.Metadata table<string, checkmate.MetadataProps>
 
 ---@class checkmate.MetadataProps
 ---Additional string values that can be used interchangably with the canonical tag name.
 ---E.g. @started could have aliases of `{"initiated", "began"}` so that @initiated and @began could
 ---also be used and have the same styling/functionality
----@field aliases string[]?
+---@field aliases? string[]
 ---
----Highlight settings or function that returns highlight settings based on the metadata's current value
----@field style vim.api.keyset.highlight|fun(value:string):vim.api.keyset.highlight
+---@alias checkmate.StyleFn
+---| fun(value: string):vim.api.keyset.highlight -- Legacy (to be removed in future release)
+---| fun(context?: checkmate.MetadataContext):vim.api.keyset.highlight
+---
+---Highlight settings table, or a function that returns highlight settings (being passed metadata context)
+---@field style? vim.api.keyset.highlight|checkmate.StyleFn
 ---
 ---Function that returns the default value for this metadata tag
----@field get_value fun():string
+---i.e. what is used after insertion
+---@field get_value? fun():string?|fun(context?: checkmate.MetadataContext):string
+---
+---@alias checkmate.ChoicesFn fun(context?: checkmate.MetadataContext, cb?: fun(items: string[])): string[]?
+---
+---Values that are populated during completion or select pickers
+---Can be either:
+--- - An array of items (string[])
+--- - A function that returns items
+---@field choices? string[]|checkmate.ChoicesFn
 ---
 ---Keymapping for toggling this metadata tag
----@field key string?
+---@field key? string
 ---
 ---Used for displaying metadata in a consistent order
----@field sort_order integer?
+---@field sort_order? integer
 ---
 ---Moves the cursor to the metadata after it is inserted
 ---  - "tag" - moves to the beginning of the tag
 ---  - "value" - moves to the beginning of the value
 ---  - false - disables jump (default)
----@field jump_to_on_insert "tag" | "value" | false?
+---@field jump_to_on_insert? "tag" | "value" | false
 ---
 ---Selects metadata text in visual mode after metadata is inserted
 ---The `jump_to_on_insert` field must be set (not false)
 ---The selected text will be the tag or value, based on jump_to_on_insert setting
 ---Default (false) - off
----@field select_on_insert boolean?
+---@field select_on_insert? boolean
 ---
 ---Callback to run when this metadata tag is added to a todo item
 ---E.g. can be used to change the todo item state
----@field on_add fun(todo_item: checkmate.TodoItem)?
+---@field on_add? fun(todo_item: checkmate.TodoItem)
 ---
 ---Callback to run when this metadata tag is removed from a todo item
 ---E.g. can be used to change the todo item state
----@field on_remove fun(todo_item: checkmate.TodoItem)?
+---@field on_remove? fun(todo_item: checkmate.TodoItem)
 
 -----------------------------------------------------
 
@@ -320,7 +345,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 -----------------------------------------------------
 
 ---@type checkmate.Config
-local _DEFAULTS = {
+local defaults = {
   enabled = true,
   notify = true,
   -- Default file matching:
@@ -348,13 +373,14 @@ local _DEFAULTS = {
     ["<leader>Tn"] = "create", -- Create todo item
     ["<leader>TR"] = "remove_all_metadata", -- Remove all metadata from a todo item
     ["<leader>Ta"] = "archive", -- Archive checked/completed todo items (move to bottom section)
+    ["<leader>Tv"] = "select_metadata_value", -- Update the value of a metadata tag under the cursor
   },
   default_list_marker = "-",
   todo_markers = {
     unchecked = "□",
     checked = "✔",
   },
-  style = {},
+  style = {}, -- override defaults
   todo_action_depth = 1, --  Depth within a todo item's hierachy from which actions (e.g. toggle) will act on the parent todo item
   enter_insert_after_new = true, -- Should enter INSERT mode after :CheckmateCreate (new todo)
   smart_toggle = {
@@ -371,8 +397,8 @@ local _DEFAULTS = {
   metadata = {
     -- Example: A @priority tag that has dynamic color based on the priority value
     priority = {
-      style = function(_value)
-        local value = _value:lower()
+      style = function(context)
+        local value = context.value:lower()
         if value == "high" then
           return { fg = "#ff5555", bold = true }
         elseif value == "medium" then
@@ -385,6 +411,9 @@ local _DEFAULTS = {
       end,
       get_value = function()
         return "medium" -- Default priority
+      end,
+      choices = function()
+        return { "low", "medium", "high" }
       end,
       key = "<leader>Tp",
       sort_order = 10,
@@ -811,7 +840,7 @@ end
 function M.setup(opts)
   local success, result = pcall(function()
     -- start with static defaults
-    local config = vim.deepcopy(_DEFAULTS)
+    local config = vim.deepcopy(defaults)
 
     -- then merge global config if present
     if type(vim.g.checkmate_config) == "table" then
@@ -845,7 +874,7 @@ function M.setup(opts)
 end
 
 function M.get_defaults()
-  return vim.deepcopy(_DEFAULTS)
+  return vim.deepcopy(defaults)
 end
 
 return M

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -156,9 +156,11 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 
 ---@class checkmate.UISettings
 ---
+---@alias checkmate.Picker "telescope" | "snacks" | "mini" | false | fun(items: string[], opts: {on_choice: function})
 ---Default behavior: attempt to use an installed plugin, if found
 ---If false, will default to vim.ui.select
----@field preferred_picker? "telescope" | "snacks" | "mini" | false
+---If a function is passed, will use this picker implementation
+---@field picker? checkmate.Picker
 
 -----------------------------------------------------
 

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -39,55 +39,34 @@ function M.get_buffer_line(bufnr, row)
   return cache:get(row)
 end
 
----Some highlights are created from factory functions via the config module. Instead of re-running these every time
----highlights are re-applied, we cache the results of the highlight generating functions
-M._dynamic_highlight_cache = {
-  metadata = {},
-}
+-- Maps hash -> { highlight_group, style }
+M._style_cache = {}
 
--- Generic function to get or create a dynamic highlight group
----@param category string The category of highlight (e.g., 'metadata', etc.)
----@param key string A unique identifier within the category
----@param base_name string The base name for the highlight group
----@param style_fn function|table A function that returns style options or a style table directly
----@return string highlight_group The name of the highlight group
-function M.get_or_create_dynamic_highlight(category, key, base_name, style_fn)
-  -- Initialize category if needed
-  M._dynamic_highlight_cache[category] = M._dynamic_highlight_cache[category] or {}
+-- Simple hash function for style tables
+local function hash_style(style)
+  local keys = vim.tbl_keys(style)
+  table.sort(keys)
 
-  if M._dynamic_highlight_cache[category][key] then
-    return M._dynamic_highlight_cache[category][key]
+  local parts = {}
+  for _, key in ipairs(keys) do
+    local value = style[key]
+    if type(value) == "string" or type(value) == "number" or type(value) == "boolean" then
+      table.insert(parts, key .. ":" .. tostring(value))
+    end
   end
 
-  -- a simple size limit on the cache (shouldnt need this)
-  local cache = M._dynamic_highlight_cache[category] or {}
-  if vim.tbl_count(cache) > 200 then
-    M._dynamic_highlight_cache[category] = {}
+  -- Create a hash from the concatenated string
+  local str = table.concat(parts, ",")
+  local hash = 0
+  for i = 1, #str do
+    hash = (hash * 31 + string.byte(str, i)) % 2147483647
   end
 
-  local highlight_group = base_name .. "_" .. key:gsub("[^%w]", "_")
-
-  -- Apply style - handle both functions and direct style tables
-  local style = type(style_fn) == "function" and style_fn(key) or style_fn
-
-  -- Create the highlight group
-  ---@diagnostic disable-next-line: param-type-mismatch
-  vim.api.nvim_set_hl(0, highlight_group, style)
-
-  -- Cache it
-  M._dynamic_highlight_cache[category][key] = highlight_group
-
-  return highlight_group
+  return tostring(hash)
 end
 
--- Clear cache for a specific category or all categories
----@param category? string Optional category to clear (nil clears all)
-function M.clear_highlight_cache(category)
-  if category then
-    M._dynamic_highlight_cache[category] = {}
-  else
-    M._dynamic_highlight_cache = {}
-  end
+function M.clear_highlight_cache()
+  M._style_cache = {}
 end
 
 function M.register_highlight_groups()
@@ -125,7 +104,7 @@ function M.register_highlight_groups()
     -- Function-based styles will be processed during actual highlighting
     if type(meta_props.style) ~= "function" then
       ---@diagnostic disable-next-line: assign-type-mismatch
-      highlights["CheckmateMeta_" .. meta_name] = meta_props.style
+      highlights["CheckmateMeta" .. "_" .. meta_name] = meta_props.style
     end
   end
 
@@ -496,9 +475,12 @@ end
 ---Applies highlight groups to metadata entries
 ---@param bufnr integer Buffer number
 ---@param config checkmate.Config.mod Configuration module
----@param metadata checkmate.TodoMetadata The metadata for this todo item
-function M.highlight_metadata(bufnr, config, metadata)
+---@param todo_item checkmate.TodoItem Todo item for this metadata
+function M.highlight_metadata(bufnr, config, todo_item)
   local log = require("checkmate.log")
+  local meta_module = require("checkmate.metadata")
+
+  local metadata = todo_item.metadata
 
   if not metadata or not metadata.entries or #metadata.entries == 0 then
     return
@@ -514,11 +496,24 @@ function M.highlight_metadata(bufnr, config, metadata)
       local highlight_group
 
       if type(meta_config.style) == "function" then
-        local cache_key = canonical_name .. "_" .. value
-        highlight_group = M.get_or_create_dynamic_highlight("metadata", cache_key, "CheckmateMeta", function()
-          return meta_config.style(value)
-        end)
+        local context = meta_module.create_context(todo_item, canonical_name, value, bufnr)
+        local style = meta_module.evaluate_style(meta_config, context)
+
+        local style_hash = hash_style(style)
+
+        if M._style_cache[style_hash] then
+          highlight_group = M._style_cache[style_hash].highlight_group
+        else
+          highlight_group = "CheckmateMeta_" .. canonical_name .. "_" .. style_hash
+          vim.api.nvim_set_hl(0, highlight_group, style)
+
+          M._style_cache[style_hash] = {
+            highlight_group = highlight_group,
+            style = style,
+          }
+        end
       else
+        -- static styles
         highlight_group = "CheckmateMeta_" .. canonical_name
       end
 
@@ -668,7 +663,7 @@ function M.highlight_content(bufnr, todo_item, todo_map)
     end
   end
 
-  M.highlight_metadata(bufnr, config, todo_item.metadata)
+  M.highlight_metadata(bufnr, config, todo_item)
 end
 
 ---Show todo count indicator

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -141,7 +141,7 @@ M.setup = function(opts)
 
     local cfg = config.setup(opts or {})
     if vim.tbl_isempty(cfg) then
-      error("config setup failed")
+      error()
     end
 
     M.set_initialized(true)
@@ -152,7 +152,11 @@ M.setup = function(opts)
   end)
 
   if not success then
-    vim.notify("Checkmate: Setup failed: " .. tostring(err), vim.log.levels.ERROR)
+    local msg = "Checkmate: Setup failed"
+    if err then
+      msg = msg .. ": " .. tostring(err)
+    end
+    vim.notify(msg, vim.log.levels.ERROR)
     M.reset()
     return false
   end

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -8,13 +8,16 @@ local M = {}
 ---@field state checkmate.TodoItemState
 ---@field text string First line of the todo
 ---@field metadata string[][] Table of {tag, value} tuples
----@field get_metadata fun(name: string): string[]?
+---@field is_checked fun(): boolean Whether todo is checked (vs unchecked)
+---@field get_metadata fun(name: string): string?, string? Returns 1. tag, 2. value, if exists
 
 ---@class checkmate.MetadataContext
 ---@field name string Metadata tag name
 ---@field value string Current metadata value
 ---@field todo checkmate.Todo Access to todo item data
 ---@field buffer integer Buffer number
+
+--- internal
 
 local state = {
   initialized = false,
@@ -702,6 +705,10 @@ function M.toggle_metadata(meta_name, custom_value)
   return true
 end
 
+---Opens a picker to select a new value for the metadata under the cursor
+---
+---Set `config.ui.preferred_picker` to designate a specific picker implementation
+---Otherwise, will attempt to use an installed picker UI plugin, or fallback to native vim.ui.select
 function M.select_metadata_value()
   local api = require("checkmate.api")
   local transaction = require("checkmate.transaction")

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -730,6 +730,24 @@ function M.select_metadata_value()
   end)
 end
 
+--- Move the cursor to the next metadata tag for the todo item under the cursor, if present
+function M.jump_next_metadata()
+  local api = require("checkmate.api")
+  local bufnr = vim.api.nvim_get_current_buf()
+  local todo_items = api.collect_todo_items_from_selection(false)
+
+  api.move_cursor_to_metadata(bufnr, todo_items[1], false)
+end
+
+--- Move the cursor to the previous metadata tag for the todo item under the cursor, if present
+function M.jump_previous_metadata()
+  local api = require("checkmate.api")
+  local bufnr = vim.api.nvim_get_current_buf()
+  local todo_items = api.collect_todo_items_from_selection(false)
+
+  api.move_cursor_to_metadata(bufnr, todo_items[1], true)
+end
+
 --- Lints the current Checkmate buffer according to the plugin's enabled custom linting rules
 ---
 --- This is not intended to be a comprehensive Markdown linter

--- a/lua/checkmate/metadata/init.lua
+++ b/lua/checkmate/metadata/init.lua
@@ -1,0 +1,315 @@
+local M = {}
+
+M._deprecation_msg_shown = false
+
+---Creates a metadata context object
+---@param todo_item checkmate.TodoItem Todo item containing the metadata
+---@param meta_name string The metadata tag name (canonical, not alias)
+---@param value string Metadata value
+---@param bufnr integer Buffer number
+---@return checkmate.MetadataContext
+function M.create_context(todo_item, meta_name, value, bufnr)
+  local metadata_array = {}
+  for _, entry in ipairs(todo_item.metadata.entries) do
+    table.insert(metadata_array, { entry.tag, entry.value })
+  end
+
+  local function get_metadata(name)
+    local result = vim
+      .iter(metadata_array)
+      :filter(function(m)
+        return m[1] == name
+      end)()
+    return result[1], result[2]
+  end
+
+  return {
+    value = value,
+    name = meta_name,
+    ---@type checkmate.Todo
+    todo = {
+      _todo_item = todo_item,
+      state = todo_item.state,
+      text = todo_item.todo_text,
+      metadata = metadata_array,
+      get_metadata = get_metadata,
+    },
+    buffer = bufnr,
+  }
+end
+
+---Evaluates a `metadata.style` (table or getter function) to return a highlight tbl
+---Handles both legacy and new function signatures
+--- TODO: remove legacy in v0.10+
+---
+---@param meta_props checkmate.MetadataProps Metadata properties, from the configuration
+---@param context checkmate.MetadataContext
+---@return vim.api.keyset.highlight hl The highlight table
+function M.evaluate_style(meta_props, context)
+  local style = meta_props.style
+  if type(style) ~= "function" then
+    ---@cast style vim.api.keyset.highlight
+    -- return static style as-is
+    return style
+  end
+  ---@cast style checkmate.StyleFn
+
+  --we determine new vs. legacy by just trying it and seeing if new fails
+  local success, result = pcall(style, context)
+
+  if success then
+    return result
+  else
+    -- failed, try legacy signature
+    M.show_deprecation_msg()
+    success, result = pcall(style, context.value)
+    if success then
+      return result
+    else
+      return {}
+    end
+  end
+end
+
+---Evaluates a metadata value getter function
+---Handles both legacy and new signatures
+---
+--- TODO: remove legacy in v0.10+
+---
+---@param meta_props checkmate.MetadataProps Metadata properties, from the configuration
+---@param context checkmate.MetadataContext?
+---@return string value value
+function M.evaluate_value(meta_props, context)
+  local get_value = meta_props.get_value
+  if not get_value then
+    return ""
+  end
+
+  local success, result = pcall(function()
+    local info = debug.getinfo(get_value, "u")
+
+    -- if no params, this is legacy
+    if info.nparams == 0 or not context then
+      return tostring(get_value() or "")
+    end
+
+    return tostring(get_value(context) or "")
+  end)
+
+  if success then
+    return result
+  else
+    vim.notify("Checkmate: error calling get_value: " .. result, vim.log.levels.ERROR)
+    return ""
+  end
+end
+
+---@param context checkmate.MetadataContext
+---@param cb fun(items: string[])
+---@return table?
+function M.evaluate_choices(context, cb)
+  local metadata_props = M.get_meta_props(context.name) or {}
+  local choices = metadata_props.choices or {}
+
+  if not choices then
+    return cb({})
+  end
+
+  if type(choices) == "table" then
+    return cb(choices)
+  elseif type(choices) == "function" then
+    local state = {
+      callback_invoked = false,
+      timeout_id = nil,
+    }
+
+    local wrapped_callback = function(items)
+      state.callback_invoked = true
+      if state.timeout_id then
+        vim.fn.timer_stop(state.timeout_id)
+        state.timeout_id = nil
+      end
+      return cb(items)
+    end
+
+    local success, result = pcall(choices, context, wrapped_callback)
+
+    if success then
+      -- user returned items directly (sync)
+      if type(result) == "table" and not state.callback_invoked then
+        return cb(result)
+      end
+
+      -- user using async pattern
+      if not state.callback_invoked then
+        -- timeout
+        state.timeout_id = vim.fn.timer_start(5000, function()
+          if not state.callback_invoked then
+            vim.notify(
+              string.format("Checkmate: 'choices' function timed out for @%s", context.name),
+              vim.log.levels.WARN
+            )
+            cb({})
+          end
+        end)
+        return
+      end
+
+      -- callback was already invoked
+      return
+    end
+
+    -- 2-param call failed, try with just context
+    success, result = pcall(choices, context)
+    if success and type(result) == "table" then
+      return cb(result)
+    end
+
+    -- try with no params
+    success, result = pcall(choices)
+    if success and type(result) == "table" then
+      return cb(result)
+    end
+
+    -- all attempts failed
+    vim.notify(string.format("Checkmate: failed to get choices for @%s", context.name), vim.log.levels.ERROR)
+    cb({})
+  end
+end
+
+---Gets choices for a metadata tag
+---Requires a todo item and buffer to provide sufficient context
+---to the 'choices' function supplied by the user
+---@param meta_name string The metadata tag name (or alias)
+---@param callback fun(items: string[])
+---@param todo_item checkmate.TodoItem
+---@param bufnr integer
+function M.get_choices(meta_name, callback, todo_item, bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return callback({})
+  end
+
+  local canonical_name = M.get_canonical_name(meta_name)
+  if not canonical_name then
+    return callback({})
+  end
+
+  ---@type checkmate.MetadataEntry
+  local entry = todo_item.metadata and todo_item.metadata.by_tag and todo_item.metadata.by_tag[canonical_name]
+  local value = entry and entry.value or ""
+
+  local context = M.create_context(todo_item, canonical_name, value, bufnr)
+
+  M.evaluate_choices(context, callback)
+end
+
+---Gets the canonical name for a metadata tag (resolving aliases)
+---@param meta_name string The metadata tag name (might be an alias)
+---@return string|nil canonical_name The canonical metadata name, or nil if it doesn't exist
+function M.get_canonical_name(meta_name)
+  local config = require("checkmate.config")
+
+  -- already a canonical name
+  if config.options.metadata[meta_name] then
+    return meta_name
+  end
+
+  -- check aliases
+  for canonical_name, meta_props in pairs(config.options.metadata) do
+    if meta_props.aliases then
+      for _, alias in ipairs(meta_props.aliases) do
+        if alias == meta_name then
+          return canonical_name
+        end
+      end
+    end
+  end
+
+  return nil
+end
+
+---Gets metadata properties by name
+---@param meta_name string Metadata name or alias
+---@return checkmate.MetadataProps? meta_props The metadata props (config)
+function M.get_meta_props(meta_name)
+  local config = require("checkmate.config")
+  local canonical = M.get_canonical_name(meta_name)
+  return config.options.metadata[canonical]
+end
+
+---Checks if a todo item has a specific metadata tag
+---@param todo_item checkmate.TodoItem Todo item
+---@param meta_name string Metadata tag name (or alias)
+---@param predicate? string|fun(meta_value):boolean
+---@return boolean has_metadata Whether the given todo has the metadata, only if passing the given value predicate (optional)
+---@return checkmate.MetadataEntry? entry Metadata entry if found
+function M.has_metadata(todo_item, meta_name, predicate)
+  if not todo_item.metadata or not todo_item.metadata.by_tag then
+    return false, nil
+  end
+
+  local canonical = M.get_canonical_name(meta_name)
+  local entry = todo_item.metadata.by_tag[canonical] or todo_item.metadata.by_tag[meta_name]
+
+  if not entry then
+    return false, nil
+  end
+
+  if predicate ~= nil then
+    local pass = false
+    if type(predicate) == "string" then
+      pass = entry.value == predicate
+    end
+    if type(predicate) == "function" then
+      pass = predicate(entry.value)
+    end
+    if pass then
+      return true, entry
+    else
+      return false
+    end
+  else
+    return true, entry
+  end
+end
+
+--- Find metadata entry at col position on todo line
+---@param todo_item checkmate.TodoItem
+---@param col integer 0-based column position
+---@return checkmate.MetadataEntry?
+function M.find_metadata_at_col(todo_item, col)
+  local metadata = todo_item.metadata.entries
+  if not metadata or #metadata == 0 then
+    return nil
+  end
+
+  for _, entry in ipairs(metadata) do
+    -- range is end-exclusive so we check col < end_col
+    if col >= entry.range.start.col and col < entry.range["end"].col then
+      return entry
+    end
+  end
+
+  return nil
+end
+
+function M.show_deprecation_msg()
+  if not M._deprecation_msg_shown then
+    vim.schedule(function()
+      vim.notify(
+        "Checkmate: One or more metadata are using the deprecated `style` function. Please update to accept a `MetadataContext` object.",
+        vim.log.levels.WARN
+      )
+      M._deprecation_msg_shown = true
+    end)
+  end
+end
+
+---Reset internal state
+function M.reset()
+  M._deprecation_msg_shown = false
+end
+
+return M

--- a/lua/checkmate/metadata/picker.lua
+++ b/lua/checkmate/metadata/picker.lua
@@ -1,0 +1,140 @@
+local parser = require("checkmate.parser")
+local meta_module = require("checkmate.metadata")
+local picker = require("checkmate.picker")
+local animation = require("checkmate.ui.animation")
+local util = require("checkmate.util")
+
+local M = {}
+
+local ns_id = vim.api.nvim_create_namespace("checkmate_metadata_picker")
+
+--- bufnr -> {spinner}
+---@type table<integer, {spinner: AnimationState}>
+local active_pickers = {}
+
+-- separate from cleanup_ui so that we can stop the spinner but keep other highlight
+local function cleanup_spinner(bufnr)
+  local active_picker = active_pickers[bufnr]
+  if active_picker and active_picker.spinner then
+    active_picker.spinner:stop()
+    active_picker.spinner = nil
+  end
+end
+
+function M.cleanup_ui(bufnr)
+  cleanup_spinner(bufnr)
+
+  if active_pickers[bufnr] then
+    active_pickers[bufnr] = nil
+  end
+
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    vim.api.nvim_buf_clear_namespace(bufnr, ns_id, 0, -1)
+  end
+end
+
+--- open a picker for the metadata under the cursor.
+function M.open_picker(on_select)
+  local bufnr = vim.api.nvim_get_current_buf()
+
+  if active_pickers[bufnr] then
+    return
+  end
+
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  row = row - 1 -- to 0-index
+
+  -- cleanup any prior
+  M.cleanup_ui(bufnr)
+
+  local todo_item = parser.get_todo_item_at_position(bufnr, row, col)
+
+  if not todo_item then
+    util.notify("No todo item at cursor", vim.log.levels.INFO)
+    return
+  end
+
+  local selected_metadata = meta_module.find_metadata_at_col(todo_item, col)
+
+  if not selected_metadata then
+    util.notify("No metadata tag at cursor", vim.log.levels.INFO)
+    return
+  end
+  ---@cast selected_metadata checkmate.MetadataEntry
+
+  -- highlight the metadata being updated
+  vim.api.nvim_buf_set_extmark(bufnr, ns_id, selected_metadata.range.start.row, selected_metadata.range.start.col, {
+    hl_group = "DiagnosticVirtualTextInfo",
+    end_row = selected_metadata.range.start.row,
+    end_col = selected_metadata.range["end"].col,
+    priority = 250,
+  })
+
+  local spinner = animation.virt_line({
+    bufnr = bufnr,
+    row = row,
+    col = 0,
+    text = "Loading completions...",
+    hl_group = "Comment",
+    interval = 50,
+  })
+
+  active_pickers[bufnr] = {
+    spinner = spinner,
+  }
+
+  -- this is the cb that is passed as paraemter in the 'choices' function
+  -- i.e., the user should call the cb when they have obtained the async results
+  local function handle_completions(items)
+    local active_op = active_pickers[bufnr]
+    if not active_op then
+      return
+    end
+
+    cleanup_spinner(bufnr)
+
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+
+    vim.schedule(function()
+      if not items or #items == 0 then
+        vim.notify(string.format("Checkmate: No choices available for @%s", selected_metadata.tag), vim.log.levels.INFO)
+        M.cleanup_ui(bufnr)
+        return
+      end
+      picker.select(items, {
+        prompt = "Select value for @" .. selected_metadata.tag,
+        format_item = function(item)
+          if item == selected_metadata.value then
+            return item .. " (current)"
+          end
+          return item
+        end,
+        on_choice = function(choice)
+          vim.schedule(function()
+            M.cleanup_ui(bufnr)
+          end)
+          if choice and choice ~= selected_metadata.value then
+            on_select(choice, selected_metadata)
+          end
+        end,
+      })
+    end)
+  end
+
+  local success, result = pcall(function()
+    return meta_module.get_choices(selected_metadata.tag, handle_completions, todo_item, bufnr)
+  end)
+
+  if not success then
+    M.cleanup_ui(bufnr)
+    vim.notify(
+      string.format("Checkmate: Error getting completions for @%s: %s", selected_metadata.tag, tostring(result)),
+      vim.log.levels.ERROR
+    )
+    return
+  end
+end
+
+return M

--- a/lua/checkmate/metadata/picker.lua
+++ b/lua/checkmate/metadata/picker.lua
@@ -97,12 +97,13 @@ function M.open_picker(on_select)
       return
     end
 
+    if not items or vim.tbl_count(items) == 0 then
+      vim.notify(string.format("Checkmate: No choices available for @%s", selected_metadata.tag), vim.log.levels.INFO)
+      M.cleanup_ui(bufnr)
+      return
+    end
+
     vim.schedule(function()
-      if not items or #items == 0 then
-        vim.notify(string.format("Checkmate: No choices available for @%s", selected_metadata.tag), vim.log.levels.INFO)
-        M.cleanup_ui(bufnr)
-        return
-      end
       picker.select(items, {
         prompt = "Select value for @" .. selected_metadata.tag,
         format_item = function(item)

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -47,7 +47,7 @@ local M = {}
 --- @field todo_marker TodoMarkerInfo Information about the todo marker (0-indexed position)
 --- @field list_marker checkmate.ListMarkerInfo Information about the list marker (0-indexed position)
 --- @field metadata checkmate.TodoMetadata | {} Metadata for this todo item
---- @field todo_text string Text content of the todo item line (first line), may be truncated. Only for debugging or tests.
+--- @field todo_text string Text content of the todo item line (first line)
 --- @field children integer[] IDs of child todo items
 --- @field parent_id integer? ID of parent todo item
 

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -763,6 +763,7 @@ end
 function M.extract_metadata(line, row)
   local log = require("checkmate.log")
   local config = require("checkmate.config")
+  local meta_module = require("checkmate.metadata")
 
   ---@type checkmate.TodoMetadata
   local metadata = {
@@ -811,22 +812,9 @@ function M.extract_metadata(line, row)
     }
 
     -- check if this is an alias and map to canonical name
-    for canonical_name, meta_props in pairs(config.options.metadata) do
-      if tag == canonical_name then
-        -- This is a canonical name, no need to set alias_for
-        break
-      end
-
-      for _, alias in ipairs(meta_props.aliases or {}) do
-        if tag == alias then
-          entry.alias_for = canonical_name
-          break
-        end
-      end
-
-      if entry.alias_for then
-        break
-      end
+    local canonical_name = meta_module.get_canonical_name(tag)
+    if canonical_name and canonical_name ~= tag then
+      entry.alias_for = canonical_name
     end
 
     table.insert(metadata.entries, entry)

--- a/lua/checkmate/picker.lua
+++ b/lua/checkmate/picker.lua
@@ -1,0 +1,152 @@
+local M = {}
+
+local function has_module(name)
+  return pcall(require, name)
+end
+
+local function get_preferred_picker()
+  local config = require("checkmate.config")
+  local ui = config.options.ui
+
+  if not ui or not ui.preferred_picker then
+    return nil
+  end
+
+  if ui.preferred_picker == false then
+    return false
+  end
+
+  return ui.preferred_picker
+end
+
+-- Default window dimensions
+local DEFAULT_WIDTH = 0.4
+local DEFAULT_HEIGHT = 20
+local DEFAULT_MIN_WIDTH = 40
+
+---@class SelectOpts
+---@field prompt? string
+---@field format_item? fun(item: string): string
+---@field on_choice? fun(choice: string|nil, ...)
+---@field backend? "telescope" | "snacks" | "mini"
+
+---@param items string[] List of choices
+---@param opts SelectOpts
+function M.select(items, opts)
+  opts = opts or {}
+
+  local backend = opts.backend or get_preferred_picker()
+
+  local width = math.max(math.floor(vim.o.columns * DEFAULT_WIDTH), DEFAULT_MIN_WIDTH)
+  local height = math.min(#items + 8, DEFAULT_HEIGHT)
+
+  if (not backend or backend == "telescope") and has_module("telescope.pickers") then
+    local pickers = require("telescope.pickers")
+    local finders = require("telescope.finders")
+    local conf = require("telescope.config").values
+    local actions = require("telescope.actions")
+    local action_state = require("telescope.actions.state")
+    local themes = require("telescope.themes")
+
+    local theme_opts = themes.get_dropdown({
+      winblend = 10,
+      width = width,
+      height = height,
+      prompt_title = opts.prompt or "Edit metadata value",
+      previewer = false,
+      layout_config = {
+        width = DEFAULT_WIDTH,
+        height = height / vim.o.lines,
+      },
+    })
+
+    pickers
+      .new(theme_opts, {
+        finder = finders.new_table({
+          results = items,
+          entry_maker = function(item)
+            return {
+              value = item,
+              display = opts.format_item and opts.format_item(item) or item,
+              ordinal = item,
+            }
+          end,
+        }),
+        sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+          actions.select_default:replace(function()
+            actions.close(prompt_bufnr)
+            local selection = action_state.get_selected_entry()
+            if opts.on_choice then
+              opts.on_choice(selection and selection.value or nil)
+            end
+          end)
+
+          map("i", "<esc>", function()
+            actions.close(prompt_bufnr)
+            if opts.on_choice then
+              opts.on_choice(nil)
+            end
+          end)
+
+          return true -- keep other default mappings
+        end,
+      })
+      :find()
+    return
+  end
+
+  if (not backend or backend == "snacks") and has_module("snacks") then
+    ---@type snacks.picker.ui_select
+    require("snacks").picker.select(items, {
+      prompt = opts.prompt or "Select an item",
+      format_item = opts.format_item,
+      preview = false,
+    }, function(item)
+      opts.on_choice(item)
+    end)
+    return
+  end
+
+  if (not backend or backend == "mini") and has_module("mini.pick") then
+    local pick = require("mini.pick")
+
+    -- center position
+    local row = math.floor((vim.o.lines - height) / 2)
+    local col = math.floor((vim.o.columns - width) / 2)
+
+    pick.ui_select(
+      items,
+      {
+        prompt = opts.prompt or "Select an item",
+        format_item = opts.format_item,
+      },
+      opts.on_choice,
+      {
+        window = {
+          config = {
+            border = "rounded",
+            width = width,
+            height = height,
+            relative = "editor",
+            anchor = "NW",
+            row = row,
+            col = col,
+            title = opts.prompt or "Select an item",
+            title_pos = "center",
+          },
+        },
+      }
+    )
+    return
+  end
+
+  -- Fallback to built-in
+  vim.ui.select(items, {
+    prompt = opts.prompt,
+    format_item = opts.format_item,
+    kind = "checkmate_metadata",
+  }, opts.on_choice)
+end
+
+return M

--- a/lua/checkmate/ui/animation.lua
+++ b/lua/checkmate/ui/animation.lua
@@ -1,0 +1,135 @@
+local M = {}
+
+local uv = vim.uv or vim.loop
+
+local ns_counter = 0
+local function create_animation_ns()
+  ns_counter = ns_counter + 1
+  return vim.api.nvim_create_namespace("checkmate_animation_" .. ns_counter)
+end
+
+---@class AnimationState
+---@field idx integer current frame index
+---@field ext_id integer? current extmark id
+---@field timer uv.uv_timer_t? timer handle
+---@field bufnr integer
+---@field ns integer namespace
+---@field stopped boolean
+---@field stop? function
+
+---@class NewOpts
+---@field bufnr integer buffer (default current)
+---@field frames string[] animation frames to cycle through
+---@field render fun(frame:string, state:table):integer function to draw a frame, returns extmark id
+---@field interval? integer ms between frames (default 100)
+
+--- @param opts NewOpts
+--- @return AnimationState state animation handle with :stop()
+function M.new(opts)
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local frames = opts.frames or {}
+  local render = opts.render
+  local interval = opts.interval or 100
+
+  assert(type(frames) == "table" and #frames > 0, "new(): frames array required")
+  assert(type(render) == "function", "new(): render function required")
+
+  local ns = create_animation_ns()
+
+  ---@type AnimationState
+  local state = { idx = 1, ext_id = nil, timer = nil, bufnr = bufnr, ns = ns, stopped = false }
+
+  local function draw()
+    if state.stopped then
+      return
+    end
+    local ok, ext_id = pcall(render, frames[state.idx], state)
+    if ok and ext_id then
+      state.ext_id = ext_id
+    end
+  end
+
+  vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+
+  -- start
+  draw()
+
+  state.timer = uv.new_timer()
+  state.timer:start(
+    0,
+    interval,
+    vim.schedule_wrap(function()
+      if state.stopped or not vim.api.nvim_buf_is_valid(bufnr) then
+        state:stop()
+        return
+      end
+      state.idx = (state.idx % #frames) + 1
+      draw()
+    end)
+  )
+
+  function state:stop()
+    if self.stopped then
+      return
+    end
+
+    self.stopped = true
+
+    pcall(function()
+      if self.timer then
+        self.timer:stop()
+        self.timer:close()
+        self.timer = nil
+      end
+      if vim.api.nvim_buf_is_valid(self.bufnr) then
+        vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns, 0, -1)
+      end
+
+      self.ext_id = nil
+    end)
+  end
+
+  return state
+end
+
+---@class VirtLineOpts
+---@field bufnr? integer buffer (default current)
+---@field text? string label
+---@field row integer 0-indexed row for extmark
+---@field col? integer 0-indexed col for extmark
+---@field hl_group? string highlight group (default "Comment")
+---@field interval? integer ms between frames (default 100)
+
+---Animate a spinner via extmark virt_lines
+---@param opts VirtLineOpts
+--- @return AnimationState state animation handle with :stop()
+function M.virt_line(opts)
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local row = opts.row
+  local col = opts.col or 0
+  local label = opts.text or ""
+  local hl = opts.hl_group or "Comment"
+  local interval = opts.interval or 80
+
+  local frames = { "⠋", "⠙", "⠚", "⠞", "⠖", "⠦", "⠴", "⠲", "⠳", "⠓" }
+
+  local function render(frame, state)
+    local virt = frame .. (label ~= "" and " " .. label or "")
+    local mark_opts = {
+      virt_lines = { { { virt, hl } } },
+      virt_lines_above = false,
+      id = state.ext_id,
+      priority = 100,
+    }
+    return vim.api.nvim_buf_set_extmark(state.bufnr, state.ns, row, col, mark_opts)
+  end
+
+  return M.new({
+    bufnr = bufnr,
+    frames = frames,
+    render = render,
+    interval = interval,
+  })
+end
+
+return M

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -600,6 +600,41 @@ function M.byte_to_char_col(line, byte_col)
   return char_idx
 end
 
+---Creates a public facing checkmate.Todo from the internal checkmate.TodoItem representation
+---
+---exposes a public api while still providing access to the underlying todo_item
+---@param todo_item checkmate.TodoItem
+---@return checkmate.Todo
+function M.build_todo(todo_item)
+  local metadata_array = {}
+  for _, entry in ipairs(todo_item.metadata.entries) do
+    table.insert(metadata_array, { entry.tag, entry.value })
+  end
+
+  local function get_metadata(name)
+    local result = vim
+      .iter(metadata_array)
+      :filter(function(m)
+        return m[1] == name
+      end)()
+    return result[1], result[2]
+  end
+
+  local function is_checked()
+    return todo_item.state == "checked"
+  end
+
+  ---@type checkmate.Todo
+  return {
+    _todo_item = todo_item,
+    state = todo_item.state,
+    text = todo_item.todo_text,
+    metadata = metadata_array,
+    is_checked = is_checked,
+    get_metadata = get_metadata,
+  }
+end
+
 -- Cursor helper
 M.Cursor = {}
 

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -22,7 +22,6 @@ describe("API", function()
       local unchecked = h.get_unchecked_marker()
       local checked = h.get_checked_marker()
 
-      -- Initial content with Unicode symbols, hierarchical structure, and different list markers
       local content = [[
 # Complex Todo List
 ## Work Tasks
@@ -469,78 +468,511 @@ Line 2
   end)
 
   describe("todo manipulation", function()
-    it("should add metadata to todo items", function()
-      local unchecked = h.get_unchecked_marker()
+    describe("metadata operations", function()
+      it("should add metadata to todo items", function()
+        local unchecked = h.get_unchecked_marker()
 
-      local content = "# Todo List\n\n- [ ] Task without metadata\n"
+        local content = "# Todo List\n\n- [ ] Task without metadata\n"
 
-      local bufnr, file_path = h.setup_todo_buffer(content)
+        local bufnr, file_path = h.setup_todo_buffer(content)
 
-      vim.api.nvim_win_set_cursor(0, { 3, 0 })
+        vim.api.nvim_win_set_cursor(0, { 3, 0 })
 
-      local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 2, 0)
-      assert.is_not_nil(todo_item)
+        local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 2, 0)
+        assert.is_not_nil(todo_item)
 
-      local success = require("checkmate").add_metadata("priority", "high")
-      assert.is_true(success)
+        local success = require("checkmate").add_metadata("priority", "high")
+        assert.is_true(success)
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-      assert.matches("- " .. vim.pesc(unchecked) .. " Task without metadata @priority%(high%)", lines[3])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Task without metadata @priority%(high%)", lines[3])
 
-      vim.cmd("write")
-      vim.cmd("sleep 10m")
+        vim.cmd("write")
+        vim.cmd("sleep 10m")
 
-      local saved_content = h.read_file_content(file_path)
-      if not saved_content then
-        error("error reading file content")
-      end
+        local saved_content = h.read_file_content(file_path)
+        if not saved_content then
+          error("error reading file content")
+        end
 
-      assert.matches("- %[ %] Task without metadata @priority%(high%)", saved_content)
+        assert.matches("- %[ %] Task without metadata @priority%(high%)", saved_content)
 
-      finally(function()
-        h.cleanup_buffer(bufnr, file_path)
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
       end)
-    end)
 
-    it("should add metadata to a nested todo item", function()
-      local unchecked = h.get_unchecked_marker()
+      it("should add metadata to a nested todo item", function()
+        local unchecked = h.get_unchecked_marker()
 
-      local content = [[
+        local content = [[
 - [ ] Parent todo
   - [ ] Child todo A
   - [ ] Child todo B
 ]]
-      local bufnr, file_path = h.setup_todo_buffer(content)
+        local bufnr, file_path = h.setup_todo_buffer(content)
 
-      -- move cursor to the Child todo A on line 2 (1-indexed)
-      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+        -- move cursor to the Child todo A on line 2 (1-indexed)
+        vim.api.nvim_win_set_cursor(0, { 2, 0 })
 
-      local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 1, 0) -- 0-indexed
-      assert.is_not_nil(todo_item)
+        local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 1, 0) -- 0-indexed
+        assert.is_not_nil(todo_item)
 
-      require("checkmate").add_metadata("priority", "high")
+        require("checkmate").add_metadata("priority", "high")
 
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-      assert.matches("- " .. vim.pesc(unchecked) .. " Parent todo", lines[1])
-      assert.matches("- " .. vim.pesc(unchecked) .. " Child todo A @priority%(high%)", lines[2])
-      assert.matches("- " .. vim.pesc(unchecked) .. " Child todo B", lines[3])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Parent todo", lines[1])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Child todo A @priority%(high%)", lines[2])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Child todo B", lines[3])
 
-      -- Now repeat for the parent todo
+        -- Now repeat for the parent todo
 
-      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
 
-      local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 0, 0)
-      assert.is_not_nil(todo_item)
+        todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 0, 0)
+        assert.is_not_nil(todo_item)
 
-      -- Add @priority metadata
-      require("checkmate").add_metadata("priority", "medium")
+        -- Add @priority metadata
+        require("checkmate").add_metadata("priority", "medium")
 
-      lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-      assert.matches("- " .. vim.pesc(unchecked) .. " Parent todo @priority%(medium%)", lines[1])
-      assert.matches("- " .. vim.pesc(unchecked) .. " Child todo", lines[2])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Parent todo @priority%(medium%)", lines[1])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Child todo", lines[2])
+
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
+      end)
+
+      it("should remove metadata with complex value", function()
+        local unchecked = h.get_unchecked_marker()
+
+        local content = [[
+- [ ] Task @issue(issue #1 - fix(api): broken! @author)
+      ]]
+
+        local bufnr, file_path = h.setup_todo_buffer(content)
+
+        local todo_map = require("checkmate.parser").discover_todos(bufnr)
+        local first_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " Task @issue")
+
+        assert.is_not_nil(first_todo)
+        ---@cast first_todo checkmate.TodoItem
+
+        assert.is_not_nil(first_todo.metadata)
+        assert.is_true(#first_todo.metadata.entries > 0)
+
+        -- remove @issue
+        vim.api.nvim_win_set_cursor(0, { first_todo.range.start.row + 1, 0 }) -- adjust from 0 index to 1-indexed
+        require("checkmate").remove_metadata("issue")
+
+        vim.cmd("sleep 10m")
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        assert.no.matches("@issue", lines[1])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Task", lines[1])
+
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
+      end)
+
+      it("should remove all metadata from todo items", function()
+        local unchecked = h.get_unchecked_marker()
+
+        local tags_on_removed_called = false
+
+        -- content with todos that have multiple metadata tags
+        local content = [[
+# Todo Metadata Test
+
+- ]] .. unchecked .. [[ Task with @priority(high) @due(2023-05-15) @tags(important,urgent)
+- ]] .. unchecked .. [[ Another task @priority(medium) @assigned(john)
+- ]] .. unchecked .. [[ A todo without metadata
+]]
+
+        local bufnr, file_path = h.setup_todo_buffer(content, {
+          config = {
+            metadata = {
+              ---@diagnostic disable-next-line: missing-fields
+              tags = {
+                on_remove = function()
+                  tags_on_removed_called = true
+                end,
+              },
+            },
+          },
+        })
+
+        -- get 1st todo
+        local todo_map = require("checkmate.parser").discover_todos(bufnr)
+        local first_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " Task with")
+
+        assert.is_not_nil(first_todo)
+        ---@cast first_todo checkmate.TodoItem
+
+        assert.is_not_nil(first_todo.metadata)
+        assert.is_true(#first_todo.metadata.entries > 0)
+
+        -- remove all metadata
+        vim.api.nvim_win_set_cursor(0, { first_todo.range.start.row + 1, 0 }) -- adjust from 0 index to 1-indexed
+        require("checkmate").remove_all_metadata()
+
+        vim.cmd("sleep 10m")
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        assert.no.matches("@priority", lines[3])
+        assert.no.matches("@due", lines[3])
+        assert.no.matches("@tags", lines[3])
+        assert.matches("- " .. vim.pesc(unchecked) .. " Task with", lines[3])
+
+        assert.is_true(tags_on_removed_called)
+
+        local second_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " Another task")
+        local third_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " A todo without")
+
+        assert.is_not_nil(second_todo)
+        ---@cast second_todo checkmate.TodoItem
+
+        assert.is_not_nil(third_todo)
+        ---@cast third_todo checkmate.TodoItem
+
+        h.make_selection(first_todo.range.start.row + 1, 0, third_todo.range.start.row + 1, 0, "V")
+
+        require("checkmate").remove_all_metadata()
+
+        vim.cmd("sleep 10m")
+        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        -- second todo's metadata was removed
+        assert.no.matches("@priority", lines[4])
+        assert.no.matches("@assigned", lines[4])
+
+        -- third todo's line text wasn't changed
+        assert.matches("A todo without metadata", lines[5])
+
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
+      end)
+
+      it("should provide static choices", function()
+        local meta_module = require("checkmate.metadata")
+
+        local unchecked = h.get_unchecked_marker()
+        local content = [[- ]] .. unchecked .. [[ Task with metadata @status()]]
+
+        local bufnr, file_path = h.setup_todo_buffer(content, {
+          config = {
+            metadata = {
+              status = {
+                choices = { "todo", "in-progress", "done", "blocked" },
+              },
+            },
+          },
+        })
+
+        local todo_item = require("checkmate.parser").get_todo_item_at_position(bufnr, 0, 0)
+        assert.is_not_nil(todo_item)
+        ---@cast todo_item checkmate.TodoItem
+
+        local results
+        meta_module.get_choices("status", function(items)
+          results = items
+        end, todo_item, bufnr)
+        assert.same({ "todo", "in-progress", "done", "blocked" }, results)
+
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
+      end)
+
+      it("should support synchronous 'choices' functions", function()
+        local meta_module = require("checkmate.metadata")
+
+        local unchecked = h.get_unchecked_marker()
+
+        local content = [[- ]] .. unchecked .. [[ Task @assignee(john)]]
+
+        local choices_fn_called = false
+        local received_context = nil
+
+        local bufnr, file_path = h.setup_todo_buffer(content, {
+          config = {
+            metadata = {
+              assignee = {
+                choices = function(context)
+                  choices_fn_called = true
+                  received_context = context
+                  return { "john", "jane", "jack", "jill", "bob", "alice" }
+                end,
+              },
+            },
+          },
+        })
+
+        local parser = require("checkmate.parser")
+        local todo_map = parser.discover_todos(bufnr)
+        local todo_item = h.find_todo_by_text(todo_map, "Task @assignee")
+        assert.is_not_nil(todo_item)
+        ---@cast todo_item checkmate.TodoItem
+
+        local results
+        meta_module.get_choices("assignee", function(items)
+          results = items
+        end, todo_item, bufnr)
+
+        assert.is_true(choices_fn_called)
+        assert.is_not_nil(received_context)
+        ---@cast received_context checkmate.MetadataContext
+        assert.is_true(type(received_context) == "table")
+
+        assert.equal("assignee", received_context.name)
+        assert.equal(bufnr, received_context.buffer)
+        assert.same({ "john", "jane", "jack", "jill", "bob", "alice" }, results)
+
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
+      end)
+
+      it("should support asynchronous 'choices' functions", function()
+        local meta_module = require("checkmate.metadata")
+
+        local unchecked = h.get_unchecked_marker()
+        local content = [[- ]] .. unchecked .. [[ Task needing data @project()]]
+
+        local choices_fn_called = false
+        local received_context = nil
+
+        local bufnr, file_path = h.setup_todo_buffer(content, {
+          config = {
+            metadata = {
+              project = {
+                choices = function(context, callback)
+                  choices_fn_called = true
+                  received_context = context
+                  -- async operation
+                  vim.defer_fn(function()
+                    local projects = { "project-a", "project-b", "project-c" }
+                    callback(projects)
+                  end, 10)
+                end,
+              },
+            },
+          },
+        })
+
+        local parser = require("checkmate.parser")
+        local todo_map = parser.discover_todos(bufnr)
+        local todo_item = h.find_todo_by_text(todo_map, "Task needing data")
+        assert.is_not_nil(todo_item)
+        ---@cast todo_item checkmate.TodoItem
+
+        local results
+        meta_module.get_choices("project", function(items)
+          results = items
+        end, todo_item, bufnr)
+
+        -- wait up to 100ms for that deferred callback to fire
+        local ok = vim.wait(100, function()
+          return results ~= nil
+        end, 5)
+        assert.is_true(ok)
+
+        assert.is_true(choices_fn_called)
+        assert.is_not_nil(received_context)
+        ---@cast received_context checkmate.MetadataContext
+        assert.is_true(type(received_context) == "table")
+
+        assert.same({ "project-a", "project-b", "project-c" }, results)
+
+        finally(function()
+          h.cleanup_buffer(bufnr, file_path)
+        end)
+      end)
+
+      describe("metadata callbacks", function()
+        it("should call on_add only when metadata is successfully added", function()
+          local unchecked = h.get_unchecked_marker()
+
+          local content = [[
+# Metadata Callbacks Test
+
+- ]] .. unchecked .. [[ A test todo]]
+
+          -- spy to track callback execution
+          local on_add_called = false
+          local test_todo_item = nil
+
+          local bufnr, file_path = h.setup_todo_buffer(content, {
+            config = {
+              metadata = {
+                ---@diagnostic disable-next-line: missing-fields
+                test = {
+                  on_add = function(todo_item)
+                    on_add_called = true
+                    test_todo_item = todo_item
+                  end,
+                  select_on_insert = false,
+                },
+              },
+            },
+          })
+
+          -- todo item at row 2 (0-indexed)
+          local todo_map = require("checkmate.parser").discover_todos(bufnr)
+          local todo_item = h.find_todo_by_text(todo_map, "A test todo")
+          assert.is_not_nil(todo_item)
+          ---@cast todo_item checkmate.TodoItem
+
+          vim.api.nvim_win_set_cursor(0, { todo_item.range.start.row + 1, 0 })
+          local success = require("checkmate").add_metadata("test", "test_value")
+
+          vim.wait(20)
+          vim.cmd("redraw")
+
+          assert.is_true(success)
+          assert.is_true(on_add_called)
+          -- check that the todo item was passed to the callback
+          assert.is_not_nil(test_todo_item)
+
+          local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+          assert.matches("@test%(test_value%)", lines[3])
+
+          finally(function()
+            h.cleanup_buffer(bufnr, file_path)
+          end)
+        end)
+
+        it("should call on_remove only when metadata is successfully removed", function()
+          local unchecked = h.get_unchecked_marker()
+
+          local content = [[
+# Metadata Callbacks Test
+
+- ]] .. unchecked .. [[ A test todo @test(test_value)]]
+
+          -- spy to track callback execution
+          local on_remove_called = false
+          local test_todo_item = nil
+
+          local bufnr, file_path = h.setup_todo_buffer(content, {
+            config = {
+              metadata = {
+                ---@diagnostic disable-next-line: missing-fields
+                test = {
+                  on_remove = function(todo_item)
+                    on_remove_called = true
+                    test_todo_item = todo_item
+                  end,
+                },
+              },
+            },
+          })
+
+          local todo_map = require("checkmate.parser").discover_todos(bufnr)
+          local todo_item = h.find_todo_by_text(todo_map, "A test todo")
+          assert.is_not_nil(todo_item)
+          ---@cast todo_item checkmate.TodoItem
+
+          vim.api.nvim_win_set_cursor(0, { todo_item.range.start.row + 1, 0 }) -- set the cursor on the todo item
+          local success = require("checkmate").remove_metadata("test")
+
+          vim.wait(20)
+          vim.cmd("redraw")
+
+          assert.is_true(success)
+          assert.is_true(on_remove_called)
+          -- check that the todo item was passed to the callback
+          assert.is_not_nil(test_todo_item)
+
+          local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+          assert.no.matches("@test", lines[3])
+
+          finally(function()
+            h.cleanup_buffer(bufnr, file_path)
+          end)
+        end)
+
+        it("should apply metadata with on_add callback to all todos in bulk (normal and visual mode)", function()
+          local unchecked = h.get_unchecked_marker()
+
+          -- todo file with many todos
+          local total_todos = 30
+
+          -- Generate N todos, each on its own line
+          local todo_lines = {}
+          for i = 1, total_todos do
+            table.insert(todo_lines, "- " .. unchecked .. " Bulk task " .. i)
+          end
+          local content = "# Bulk Metadata Test\n\n" .. table.concat(todo_lines, "\n")
+
+          local on_add_calls = {}
+
+          -- register the metadata tag with a callback that tracks which todos are affected
+          local bufnr, file_path = h.setup_todo_buffer(content, {
+            config = {
+              metadata = {
+                ---@diagnostic disable-next-line: missing-fields
+                bulk = {
+                  on_add = function(todo_item)
+                    -- record the todo's line (1-based)
+                    table.insert(on_add_calls, todo_item.range.start.row + 1)
+                  end,
+                  select_on_insert = false,
+                },
+              },
+            },
+          })
+
+          -- Test Normal mode first
+          vim.api.nvim_win_set_cursor(0, { 3, 0 }) -- first todo line (after 2 header lines)
+          on_add_calls = {}
+          require("checkmate").toggle_metadata("bulk")
+
+          vim.wait(20)
+          vim.cmd("redraw")
+
+          -- callback fired once for todo with added metadata
+          assert.equal(1, #on_add_calls, "on_add should be called once")
+
+          -- remove all metadata for next test (reset state)
+          vim.api.nvim_win_set_cursor(0, { 3, 0 })
+          require("checkmate").remove_metadata("bulk")
+
+          vim.wait(10)
+          vim.cmd("redraw")
+
+          -- Test Visual mode
+
+          -- move to first todo
+          -- extend to last todo line
+          h.make_selection(3, 0, 2 + total_todos, 0, "V")
+
+          on_add_calls = {}
+          require("checkmate").toggle_metadata("bulk")
+          vim.cmd("normal! \27") -- exit visual mode
+
+          vim.wait(20)
+          vim.cmd("redraw")
+
+          -- callback fired once per selected todo (should be all)
+          assert.equal(total_todos, #on_add_calls, "on_add should be called for every visually-selected todo")
+          -- each line should have metadata
+          for i = 3, 2 + total_todos do
+            local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1]
+            assert.matches("@bulk", line)
+          end
+
+          finally(function()
+            h.cleanup_buffer(bufnr, file_path)
+          end)
+        end)
+      end)
     end)
 
     it("should work with todo hierarchies", function()
@@ -616,7 +1048,7 @@ Line 2
 
       local bufnr, file_path = h.setup_todo_buffer(content)
 
-      -- operations: toggle task 1, add metadata to task 2, check task 3
+      -- toggle task 1, add metadata to task 2, check task 3
 
       -- toggle task 1
       vim.api.nvim_win_set_cursor(0, { 3, 3 }) -- on Task 1
@@ -636,8 +1068,8 @@ Line 2
 
       local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-      local checked = h.get_checked_marker()
-      local unchecked = h.get_unchecked_marker()
+      local checked = config.get_defaults().todo_markers.checked
+      local unchecked = config.get_defaults().todo_markers.unchecked
 
       assert.matches("- " .. vim.pesc(checked) .. " Task 1", lines[3])
       assert.matches("- " .. vim.pesc(unchecked) .. " Task 2 @priority%(high%)", lines[4])
@@ -659,121 +1091,9 @@ Line 2
         h.cleanup_buffer(bufnr, file_path)
       end)
     end)
-
-    it("should remove metadata with complex value", function()
-      local unchecked = h.get_unchecked_marker()
-
-      local content = [[
-- [ ] Task @issue(issue #1 - fix(api): broken! @author)
-      ]]
-
-      local bufnr, file_path = h.setup_todo_buffer(content)
-
-      local todo_map = require("checkmate.parser").discover_todos(bufnr)
-      local first_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " Task @issue")
-
-      assert.is_not_nil(first_todo)
-      ---@cast first_todo checkmate.TodoItem
-
-      assert.is_not_nil(first_todo.metadata)
-      assert.is_true(#first_todo.metadata.entries > 0)
-
-      -- remove @issue
-      vim.api.nvim_win_set_cursor(0, { first_todo.range.start.row + 1, 0 }) -- adjust from 0 index to 1-indexed
-      require("checkmate").remove_metadata("issue")
-
-      vim.cmd("sleep 10m")
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-
-      assert.no.matches("@issue", lines[1])
-      assert.matches("- " .. vim.pesc(unchecked) .. " Task", lines[1])
-    end)
-
-    it("should remove all metadata from todo items", function()
-      local unchecked = h.get_unchecked_marker()
-
-      local tags_on_removed_called = false
-
-      -- content with todos that have multiple metadata tags
-      local content = [[
-# Todo Metadata Test
-
-- ]] .. unchecked .. [[ Task with @priority(high) @due(2023-05-15) @tags(important,urgent)
-- ]] .. unchecked .. [[ Another task @priority(medium) @assigned(john)
-- ]] .. unchecked .. [[ A todo without metadata
-]]
-
-      local bufnr, file_path = h.setup_todo_buffer(content, {
-        config = {
-          metadata = {
-            ---@diagnostic disable-next-line: missing-fields
-            tags = {
-              on_remove = function()
-                tags_on_removed_called = true
-              end,
-            },
-          },
-        },
-      })
-
-      -- get 1st todo
-      local todo_map = require("checkmate.parser").discover_todos(bufnr)
-      local first_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " Task with")
-
-      assert.is_not_nil(first_todo)
-      ---@cast first_todo checkmate.TodoItem
-
-      assert.is_not_nil(first_todo.metadata)
-      assert.is_true(#first_todo.metadata.entries > 0)
-
-      -- remove all metadata
-      vim.api.nvim_win_set_cursor(0, { first_todo.range.start.row + 1, 0 }) -- adjust from 0 index to 1-indexed
-      require("checkmate").remove_all_metadata()
-
-      vim.cmd("sleep 10m")
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-
-      assert.no.matches("@priority", lines[3])
-      assert.no.matches("@due", lines[3])
-      assert.no.matches("@tags", lines[3])
-      assert.matches("- " .. vim.pesc(unchecked) .. " Task with", lines[3])
-
-      assert.is_true(tags_on_removed_called)
-
-      local second_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " Another task")
-      local third_todo = h.find_todo_by_text(todo_map, "- " .. unchecked .. " A todo without")
-
-      assert.is_not_nil(second_todo)
-      ---@cast second_todo checkmate.TodoItem
-
-      assert.is_not_nil(third_todo)
-      ---@cast third_todo checkmate.TodoItem
-
-      vim.api.nvim_win_set_cursor(0, { first_todo.range.start.row + 1, 0 })
-      vim.cmd("normal! V")
-      vim.api.nvim_win_set_cursor(0, { third_todo.range.start.row + 1, 0 })
-
-      require("checkmate").remove_all_metadata()
-
-      vim.cmd("sleep 10m")
-      lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-
-      -- second todo's metadata was removed
-      assert.no.matches("@priority", lines[4])
-      assert.no.matches("@assigned", lines[4])
-
-      -- third todo's line text wasn't changed
-      assert.matches("A todo without metadata", lines[5])
-
-      finally(function()
-        h.cleanup_buffer(bufnr, file_path)
-      end)
-    end)
   end)
 
   describe("smart toggle", function()
-    local config = require("checkmate.config")
-
     local function setup_smart_toggle_buffer(content, smart_toggle_config)
       -- merge our 'testing' smart_toggle config with base config
       local config_override = {
@@ -1181,184 +1501,6 @@ Line 2
         finally(function()
           h.cleanup_buffer(bufnr, file_path)
         end)
-      end)
-    end)
-  end)
-
-  describe("metadata callbacks", function()
-    it("should call on_add only when metadata is successfully added", function()
-      local unchecked = h.get_unchecked_marker()
-
-      local content = [[
-# Metadata Callbacks Test
-
-- ]] .. unchecked .. [[ A test todo]]
-
-      -- spy to track callback execution
-      local on_add_called = false
-      local test_todo_item = nil
-
-      local bufnr, file_path = h.setup_todo_buffer(content, {
-        config = {
-          metadata = {
-            ---@diagnostic disable-next-line: missing-fields
-            test = {
-              on_add = function(todo_item)
-                on_add_called = true
-                test_todo_item = todo_item
-              end,
-              select_on_insert = false,
-            },
-          },
-        },
-      })
-
-      -- todo item at row 2 (0-indexed)
-      local todo_map = require("checkmate.parser").discover_todos(bufnr)
-      local todo_item = h.find_todo_by_text(todo_map, "A test todo")
-      assert.is_not_nil(todo_item)
-      ---@cast todo_item checkmate.TodoItem
-
-      vim.api.nvim_win_set_cursor(0, { todo_item.range.start.row + 1, 0 })
-      local success = require("checkmate").add_metadata("test", "test_value")
-
-      vim.wait(20)
-      vim.cmd("redraw")
-
-      assert.is_true(success)
-      assert.is_true(on_add_called)
-      -- check that the todo item was passed to the callback
-      assert.is_not_nil(test_todo_item)
-
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-      assert.matches("@test%(test_value%)", lines[3])
-
-      finally(function()
-        h.cleanup_buffer(bufnr, file_path)
-      end)
-    end)
-
-    it("should call on_remove only when metadata is successfully removed", function()
-      local unchecked = h.get_unchecked_marker()
-
-      local content = [[
-# Metadata Callbacks Test
-
-- ]] .. unchecked .. [[ A test todo @test(test_value)]]
-
-      -- spy to track callback execution
-      local on_remove_called = false
-      local test_todo_item = nil
-
-      local bufnr, file_path = h.setup_todo_buffer(content, {
-        config = {
-          metadata = {
-            ---@diagnostic disable-next-line: missing-fields
-            test = {
-              on_remove = function(todo_item)
-                on_remove_called = true
-                test_todo_item = todo_item
-              end,
-            },
-          },
-        },
-      })
-
-      local todo_map = require("checkmate.parser").discover_todos(bufnr)
-      local todo_item = h.find_todo_by_text(todo_map, "A test todo")
-      assert.is_not_nil(todo_item)
-      ---@cast todo_item checkmate.TodoItem
-
-      vim.api.nvim_win_set_cursor(0, { todo_item.range.start.row + 1, 0 }) -- set the cursor on the todo item
-      local success = require("checkmate").remove_metadata("test")
-
-      vim.wait(20)
-      vim.cmd("redraw")
-
-      assert.is_true(success)
-      assert.is_true(on_remove_called)
-      -- check that the todo item was passed to the callback
-      assert.is_not_nil(test_todo_item)
-
-      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-      assert.no.matches("@test", lines[3])
-
-      finally(function()
-        h.cleanup_buffer(bufnr, file_path)
-      end)
-    end)
-
-    it("should apply metadata with on_add callback to all todos in bulk (normal and visual mode)", function()
-      local unchecked = h.get_unchecked_marker()
-
-      -- todo file with many todos
-      local total_todos = 30
-
-      -- Generate N todos, each on its own line
-      local todo_lines = {}
-      for i = 1, total_todos do
-        table.insert(todo_lines, "- " .. unchecked .. " Bulk task " .. i)
-      end
-      local content = "# Bulk Metadata Test\n\n" .. table.concat(todo_lines, "\n")
-
-      local on_add_calls = {}
-
-      -- register the metadata tag with a callback that tracks which todos are affected
-      local bufnr, file_path = h.setup_todo_buffer(content, {
-        config = {
-          metadata = {
-            ---@diagnostic disable-next-line: missing-fields
-            bulk = {
-              on_add = function(todo_item)
-                -- record the todo's line (1-based)
-                table.insert(on_add_calls, todo_item.range.start.row + 1)
-              end,
-              select_on_insert = false,
-            },
-          },
-        },
-      })
-
-      -- test normal mode first
-      vim.api.nvim_win_set_cursor(0, { 3, 0 }) -- first todo line (after 2 header lines)
-      on_add_calls = {}
-      require("checkmate").toggle_metadata("bulk")
-
-      vim.wait(20)
-      vim.cmd("redraw")
-
-      -- callback fired once for todo with added metadata
-      assert.equal(1, #on_add_calls, "on_add should be called once")
-
-      -- remove all metadata for next test (reset state)
-      vim.api.nvim_win_set_cursor(0, { 3, 0 })
-      require("checkmate").remove_metadata("bulk")
-
-      vim.wait(10)
-      vim.cmd("redraw")
-
-      -- Test Visual mode
-
-      -- move to first todo and extend to last todo
-      h.make_selection(3, 0, 2 + total_todos, 0, "V")
-
-      on_add_calls = {}
-      require("checkmate").toggle_metadata("bulk")
-      vim.cmd("normal! \27") -- exit visual mode
-
-      vim.wait(20)
-      vim.cmd("redraw")
-
-      -- callback fired once per selected todo (should be all)
-      assert.equal(total_todos, #on_add_calls, "on_add should be called for every visually-selected todo")
-      -- each line should have metadata
-      for i = 3, 2 + total_todos do
-        local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1]
-        assert.matches("@bulk", line)
-      end
-
-      finally(function()
-        h.cleanup_buffer(bufnr, file_path)
       end)
     end)
   end)

--- a/tests/checkmate/metadata_spec.lua
+++ b/tests/checkmate/metadata_spec.lua
@@ -51,6 +51,10 @@ describe("Metadata", function()
       assert.are_equal(todo.text, content)
       assert.are_same(todo.metadata, { { "priority", "high" }, { "started", "today" } })
 
+      assert.is_function(todo.is_checked)
+      local c = todo.is_checked()
+      assert.is_false(c)
+
       assert.is_function(todo.get_metadata)
 
       local p1, p2 = todo.get_metadata("priority")
@@ -83,16 +87,14 @@ describe("Metadata", function()
 
       local context = require("checkmate.metadata").create_context(todo_item, "priority", "high", bufnr)
 
-      ---@type checkmate.StyleFn
       local received_ctx
+      ---@type checkmate.StyleFn
       local style_fn = function(ctx)
         received_ctx = ctx
         return { fg = "#ff0000" }
       end
 
       local priority_props = vim.tbl_extend("force", config.options.metadata["priority"], { style = style_fn })
-
-      assert.same(style_fn, priority_props.style)
 
       local result
       assert.no_error(function()
@@ -102,6 +104,95 @@ describe("Metadata", function()
       assert.are_equal(received_ctx, context)
 
       assert.are_same({ fg = "#ff0000" }, result)
+    end)
+
+    it("should evaluate get_value fn", function()
+      local meta_module = require("checkmate.metadata")
+      local config = require("checkmate.config")
+
+      local unchecked = h.get_unchecked_marker()
+
+      local content = "- " .. unchecked .. " Task A @priority(high) @started(today)"
+      local bufnr = h.create_test_buffer(content)
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local todo_item = h.get_todo_at_cursor(bufnr)
+      assert.is_not_nil(todo_item)
+      ---@cast todo_item checkmate.TodoItem
+
+      local context = require("checkmate.metadata").create_context(todo_item, "priority", "high", bufnr)
+
+      local received_ctx
+      ---@type checkmate.GetValueFn
+      local get_value_fn = function(ctx)
+        received_ctx = ctx
+        return "foo"
+      end
+
+      local priority_props = vim.tbl_extend("force", config.options.metadata["priority"], { get_value = get_value_fn })
+
+      local result
+      assert.no_error(function()
+        result = meta_module.evaluate_value(priority_props, context)
+      end)
+
+      assert.are_equal(received_ctx, context)
+
+      assert.are_equal("foo", result)
+    end)
+
+    it("should evalaute choices fn", function()
+      local meta_module = require("checkmate.metadata")
+      local config = require("checkmate.config")
+
+      local unchecked = h.get_unchecked_marker()
+
+      local content = "- " .. unchecked .. " Task A @priority(high) @started(today)"
+      local bufnr = h.create_test_buffer(content)
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local todo_item = h.get_todo_at_cursor(bufnr)
+      assert.is_not_nil(todo_item)
+      ---@cast todo_item checkmate.TodoItem
+
+      local context = require("checkmate.metadata").create_context(todo_item, "priority", "high", bufnr)
+
+      ---@type table<string, checkmate.ChoicesFn|table>
+      local choices_fns = {
+        tbl = { "foo", "bar", "baz" },
+        sync_0 = function()
+          return { "foo", "bar", "baz" }
+        end,
+        ---@diagnostic disable-next-line: unused-local
+        sync_1 = function(ctx)
+          return { "foo", "bar", "baz" }
+        end,
+        ---@diagnostic disable-next-line: unused-local
+        sync_2 = function(ctx, cb)
+          return { "foo", "bar", "baz" }
+        end,
+        ---@diagnostic disable-next-line: unused-local
+        async = function(ctx, cb)
+          cb({ "foo", "bar", "baz" })
+        end,
+      }
+
+      local choices_cb = function(items)
+        assert.same({ "foo", "bar", "baz" }, items)
+      end
+
+      for _, choices in pairs(choices_fns) do
+        local priority_props = vim.tbl_extend("force", config.options.metadata["priority"], { choices = choices })
+
+        local result
+        assert.no_error(function()
+          result = meta_module.evaluate_choices(priority_props, context, choices_cb)
+        end)
+
+        assert.is_nil(result)
+      end
     end)
   end)
 end)

--- a/tests/checkmate/metadata_spec.lua
+++ b/tests/checkmate/metadata_spec.lua
@@ -1,0 +1,107 @@
+describe("Metadata", function()
+  local h = require("tests.checkmate.helpers")
+  local checkmate = require("checkmate")
+
+  lazy_setup(function()
+    -- Hide nvim_echo from polluting test output
+    stub(vim.api, "nvim_echo")
+  end)
+
+  lazy_teardown(function()
+    ---@diagnostic disable-next-line: undefined-field
+    vim.api.nvim_echo:revert()
+  end)
+
+  before_each(function()
+    _G.reset_state()
+
+    h.ensure_normal_mode()
+
+    checkmate.setup()
+  end)
+
+  after_each(function()
+    checkmate.stop()
+  end)
+
+  describe("metadata context", function()
+    it("should create a context object", function()
+      local unchecked = h.get_unchecked_marker()
+
+      local content = "- " .. unchecked .. " Task A @priority(high) @started(today)"
+      local bufnr = h.create_test_buffer(content)
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local todo_item = h.get_todo_at_cursor(bufnr)
+      assert.is_not_nil(todo_item)
+      ---@cast todo_item checkmate.TodoItem
+
+      local context = require("checkmate.metadata").create_context(todo_item, "priority", "high", bufnr)
+
+      assert.is_table(context)
+      assert.are_equal(context.buffer, bufnr)
+      assert.are_equal(context.name, "priority")
+      assert.are_equal(context.value, "high")
+
+      local todo = context.todo
+      assert.is_table(todo)
+      assert.are_equal(todo._todo_item, todo_item)
+      assert.are_equal(todo.state, "unchecked")
+      assert.are_equal(todo.text, content)
+      assert.are_same(todo.metadata, { { "priority", "high" }, { "started", "today" } })
+
+      assert.is_function(todo.get_metadata)
+
+      local p1, p2 = todo.get_metadata("priority")
+      assert.are_same("priority", p1)
+      assert.are_same("high", p2)
+
+      local s1, s2 = todo.get_metadata("started")
+      assert.are_same("started", s1)
+      assert.are_same("today", s2)
+
+      finally(function()
+        h.cleanup_buffer(bufnr)
+      end)
+    end)
+
+    it("should evaluate style fn", function()
+      local meta_module = require("checkmate.metadata")
+      local config = require("checkmate.config")
+
+      local unchecked = h.get_unchecked_marker()
+
+      local content = "- " .. unchecked .. " Task A @priority(high) @started(today)"
+      local bufnr = h.create_test_buffer(content)
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local todo_item = h.get_todo_at_cursor(bufnr)
+      assert.is_not_nil(todo_item)
+      ---@cast todo_item checkmate.TodoItem
+
+      local context = require("checkmate.metadata").create_context(todo_item, "priority", "high", bufnr)
+
+      ---@type checkmate.StyleFn
+      local received_ctx
+      local style_fn = function(ctx)
+        received_ctx = ctx
+        return { fg = "#ff0000" }
+      end
+
+      local priority_props = vim.tbl_extend("force", config.options.metadata["priority"], { style = style_fn })
+
+      assert.same(style_fn, priority_props.style)
+
+      local result
+      assert.no_error(function()
+        result = meta_module.evaluate_style(priority_props, context)
+      end)
+
+      assert.are_equal(received_ctx, context)
+
+      assert.are_same({ fg = "#ff0000" }, result)
+    end)
+  end)
+end)

--- a/tests/checkmate/picker_spec.lua
+++ b/tests/checkmate/picker_spec.lua
@@ -1,0 +1,63 @@
+local h = require("tests.checkmate.helpers")
+local checkmate = require("checkmate")
+
+describe("Picker", function()
+  lazy_setup(function()
+    -- suppress echo
+    stub(vim.api, "nvim_echo")
+  end)
+
+  lazy_teardown(function()
+    ---@diagnostic disable-next-line: undefined-field
+    vim.api.nvim_echo:revert()
+  end)
+
+  before_each(function()
+    _G.reset_state()
+    h.ensure_normal_mode()
+    checkmate.setup()
+  end)
+
+  after_each(function()
+    checkmate.stop()
+  end)
+
+  it("should fall back to vim.ui.select when ui.picker is false", function()
+    local config = require("checkmate.config")
+    local picker = require("checkmate.picker")
+
+    config.options.ui = { picker = false }
+    local items = { "x", "y" }
+    local select_stub = stub(vim.ui, "select")
+
+    picker.select(items, {})
+
+    assert.stub(select_stub).was.called(1)
+    ---@diagnostic disable-next-line: undefined-field
+    vim.ui.select:revert()
+  end)
+
+  it("should use a ui.picker function as the backend", function()
+    local config = require("checkmate.config")
+    local picker = require("checkmate.picker")
+
+    local picker_called = false
+    local received_items
+    local received_on_choice
+
+    local custom_picker = function(items, opts)
+      picker_called = true
+      received_items = items
+      received_on_choice = opts.on_choice
+    end
+
+    config.options.ui = { picker = custom_picker }
+    local items = { "x", "y" }
+
+    picker.select(items, { on_choice = function() end })
+
+    assert.is_true(picker_called)
+    assert.are_equal(items, received_items)
+    assert.is_function(received_on_choice)
+  end)
+end)

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -219,24 +219,7 @@ M.configs = {
     },
     checkmate = vim.tbl_deep_extend("force", checkmate_spec, {
       ui = {
-        picker = function(items, opts)
-          require("mini.pick").ui_select(
-            items,
-            {
-              prompt = opts.prompt or "Select an item",
-              format_item = opts.format_item,
-            },
-            opts.on_choice,
-            {
-              window = {
-                config = {
-                  border = "rounded",
-                  title = "CUSTOM MINI",
-                },
-              },
-            }
-          )
-        end,
+        picker = "fzf-lua",
       },
     }),
   },

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -78,6 +78,16 @@ local checkmate_spec = {
         }
         return colors[context.value] or { fg = "#f8f8f2" }
       end,
+      on_change = function(todo_item, old_value, new_value)
+        vim.notify(
+          string.format(
+            "todo item on row %d had @type changed from %s to %s",
+            todo_item.range.start.row,
+            old_value,
+            new_value
+          )
+        )
+      end,
     },
 
     pr = {

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -199,13 +199,46 @@ M.configs = {
         },
       },
     },
-    checkmate = checkmate_spec,
+    checkmate = vim.tbl_deep_extend("force", checkmate_spec, {
+      ui = {
+        picker = function(items, opts)
+          ---@type snacks.picker.ui_select
+          require("snacks").picker.select(items, {
+            prompt = "CUSTOM",
+            preview = false,
+          }, function(item)
+            opts.on_choice(item)
+          end)
+        end,
+      },
+    }),
   },
   mini = {
     spec = {
       { "echasnovski/mini.nvim", version = false },
     },
-    checkmate = checkmate_spec,
+    checkmate = vim.tbl_deep_extend("force", checkmate_spec, {
+      ui = {
+        picker = function(items, opts)
+          require("mini.pick").ui_select(
+            items,
+            {
+              prompt = opts.prompt or "Select an item",
+              format_item = opts.format_item,
+            },
+            opts.on_choice,
+            {
+              window = {
+                config = {
+                  border = "rounded",
+                  title = "CUSTOM MINI",
+                },
+              },
+            }
+          )
+        end,
+      },
+    }),
   },
   telescope = {
     spec = {

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -26,6 +26,73 @@ local checkmate_spec = {
       end,
     },
 
+    branch = {
+      key = "<leader>Tb",
+      choices = function(context, callback)
+        local branches = {}
+        vim.fn.jobstart({ "git", "branch", "-r" }, {
+          on_stdout = function(_, data)
+            for _, line in ipairs(data) do
+              if line ~= "" then
+                local branch = line:match("origin/(.+)")
+                if branch then
+                  table.insert(branches, branch)
+                end
+              end
+            end
+          end,
+          on_exit = function()
+            callback(branches)
+          end,
+        })
+      end,
+    },
+
+    type = {
+      key = "<leader>T5",
+      get_value = function(context)
+        local text = context.todo.text:lower()
+
+        -- Auto-detect type based on keywords
+        if text:match("bug") or text:match("fix") then
+          return "bug"
+        elseif text:match("feature") or text:match("implement") then
+          return "feature"
+        elseif text:match("refactor") then
+          return "refactor"
+        elseif text:match("doc") then
+          return "documentation"
+        else
+          return "task"
+        end
+      end,
+      choices = { "bug", "feature", "refactor", "documentation", "task", "chore" },
+      style = function(context)
+        local colors = {
+          bug = { fg = "#ff5555", bold = true },
+          feature = { fg = "#50fa7b" },
+          refactor = { fg = "#ff79c6" },
+          documentation = { fg = "#f1fa8c" },
+          task = { fg = "#8be9fd" },
+          chore = { fg = "#6272a4" },
+        }
+        return colors[context.value] or { fg = "#f8f8f2" }
+      end,
+    },
+
+    pr = {
+      key = "<leader>TP",
+      get_value = function()
+        -- Get current branch's PR number if it exists
+        local branch = vim.fn.system("git branch --show-current"):gsub("\n", "")
+        local pr_number = branch:match("(%d+)")
+        return pr_number or ""
+      end,
+      style = { fg = "#8be9fd", underline = true },
+      jump_to_on_insert = "value",
+      select_on_insert = true,
+    },
+
     priority = {
       choices = function()
         return { "low", "medium", "high" }

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -1,5 +1,97 @@
 local M = {}
 
+---@type checkmate.Config
+---@diagnostic disable-next-line: missing-fields
+local checkmate_spec = {
+  metadata = {
+    test = {
+      choices = function(ctx, cb)
+        return { "A", "B", "C" }
+      end,
+      key = "<leader>T7",
+    },
+    elapsed = {
+      key = "<leader>T6",
+      get_value = function(context)
+        local _, started_value = context.todo.get_metadata("started")
+        local _, done_value = context.todo.get_metadata("done")
+
+        if started_value and done_value then
+          local started_ts = vim.fn.strptime("%m/%d/%y %H:%M", started_value)
+          local done_ts = vim.fn.strptime("%m/%d/%y %H:%M", done_value)
+          return string.format("%.1f d", (done_ts - started_ts) / 86400)
+        end
+
+        return ""
+      end,
+    },
+
+    priority = {
+      choices = function()
+        return { "low", "medium", "high" }
+      end,
+    },
+    big = {
+      choices = function(ctx)
+        local result = {}
+        for i = 1, 100 do
+          table.insert(result, "issue #" .. i)
+        end
+        return result
+      end,
+      key = "<leader>T9",
+    },
+    issue = {
+      choices = function(context, callback)
+        local co = coroutine.create(function()
+          local handle = io.popen('curl -sS "https://api.github.com/repos/bngarren/checkmate.nvim/issues?state=open"')
+          if not handle then
+            callback({})
+            return
+          end
+
+          local chunks = {}
+          while true do
+            local chunk = handle:read(1024) -- Read 1KB at a time
+            if not chunk then
+              break
+            end
+            table.insert(chunks, chunk)
+            coroutine.yield()
+          end
+
+          handle:close()
+          local json_text = table.concat(chunks)
+
+          local ok, issues = pcall(vim.json.decode, json_text)
+          if not ok then
+            callback({})
+            return
+          end
+
+          local result = {}
+          for _, issue in ipairs(issues) do
+            local text = string.format("#%d %s", issue.number, issue.title)
+            table.insert(result, text)
+          end
+
+          callback(result)
+        end)
+
+        local function resume()
+          if coroutine.status(co) ~= "dead" then
+            coroutine.resume(co)
+            vim.defer_fn(resume, 10) -- Resume every 10ms
+          end
+        end
+
+        vim.schedule(resume)
+      end,
+      key = "<leader>T8",
+    },
+  },
+}
+
 M.configs = {
   default = {
     spec = {
@@ -8,25 +100,43 @@ M.configs = {
   },
   snacks = {
     spec = {
-      "folke/snacks.nvim",
-      priority = 1000,
-      lazy = false,
-      ---@type snacks.Config
-      opts = {
-        bigfile = { enabled = true },
-        dashboard = { enabled = false },
-        explorer = { enabled = false },
-        indent = { enabled = true },
-        input = { enabled = true },
-        picker = { enabled = true },
-        notifier = { enabled = true },
-        quickfile = { enabled = true },
-        scope = { enabled = false },
-        scroll = { enabled = false },
-        statuscolumn = { enabled = true },
-        words = { enabled = true },
+      {
+        "folke/snacks.nvim",
+        priority = 1000,
+        lazy = false,
+        ---@module "snacks"
+        ---@type snacks.Config
+        opts = {
+          bigfile = { enabled = true },
+          dashboard = { enabled = false },
+          explorer = { enabled = false },
+          indent = { enabled = true },
+          input = { enabled = true },
+          picker = { enabled = true },
+          notifier = { enabled = true },
+          quickfile = { enabled = true },
+          scope = { enabled = false },
+          scroll = { enabled = false },
+          statuscolumn = { enabled = true },
+          words = { enabled = true },
+        },
       },
     },
+    checkmate = checkmate_spec,
+  },
+  mini = {
+    spec = {
+      { "echasnovski/mini.nvim", version = false },
+    },
+    checkmate = checkmate_spec,
+  },
+  telescope = {
+    spec = {
+      "nvim-telescope/telescope.nvim",
+      tag = "0.1.8",
+      dependencies = { "nvim-lua/plenary.nvim" },
+    },
+    checkmate = checkmate_spec,
   },
 }
 

--- a/tests/interactive.lua
+++ b/tests/interactive.lua
@@ -32,7 +32,7 @@ local env = environments.get(env_name)
 
 -- base specs for all environments
 local spec = {
-  { dir = vim.uv.cwd(), opts = {}, ft = "markdown" },
+  { dir = vim.uv.cwd(), opts = env.checkmate, ft = "markdown" },
 }
 
 -- environment-specific specs


### PR DESCRIPTION
- Dedicated metadata module
  - provides a new `MetadataContext` that can be passed to metadata functions
  - helpers to evaluate the metadata config functions
    - evaluate_style - computes the metadata's style from the config `metadata.style` function
    - evaluate_value - computes the metadata value from the config `metadata.get_value` function
    - evaluate_choices - computes the metadata's choices from the config `metadata.choices` table or function
  - exposes additional helpers for working with metadata
  - a metadata `picker` implementation that exposes functions to open metadata-related pickers, e.g. for selecting values, tags (planned)
- Config changes
  - `ui` option
  - `metadata.get_value` accepts a new function signature (with context) but maintains backwards compatibility
  - new `metadata.choices` option that accepts a string array or a function that returns choices for select/picker
- picker.lua module that exposes a select() function with backend implementations for telescope, snacks, and mini
  - fallback to vim.ui.select
- animation.lua module that helps build frame based animations, e.g. a extmark-based virt_lines spinner
- New API and commands
  - `select_metadata_value` to open up a picker to choose a new value for a metadata tag
  - Jump to next/previous metadata

