### PR TITLE
config.keys refactor/improvement

### DIFF
--- a/lua/checkmate/health.lua
+++ b/lua/checkmate/health.lua
@@ -31,6 +31,24 @@ function M.check()
       "`require('render-markdown').setup({checkbox = { enabled = false }})`",
     })
   end
+
+  start("Checkmate configuration")
+  local config = require("checkmate.config")
+
+  local validation_ok, validation_err = config.validate_options(config.options)
+  if validation_ok then
+    ok("Configuration is valid")
+  else
+    error("Configuration validation failed: " .. validation_err)
+  end
+
+  if config.options.enabled then
+    ok("Checkmate is enabled")
+  else
+    warn("Checkmate is disabled", {
+      "Set `enabled = true` in your config to enable",
+    })
+  end
 end
 
 return M

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -122,9 +122,7 @@ function M.create_test_buffer(content, name)
 
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
-  if name then
-    vim.api.nvim_buf_set_name(bufnr, name)
-  end
+  vim.api.nvim_buf_set_name(bufnr, name or "todo.md")
 
   vim.bo[bufnr].filetype = "markdown"
   return bufnr

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -121,6 +121,7 @@ local checkmate_spec = {
       key = "<leader>T9",
     },
     issue = {
+      key = { "<leader>TI", "Add/remove @issue" },
       choices = function(context, callback)
         local co = coroutine.create(function()
           local handle = io.popen('curl -sS "https://api.github.com/repos/bngarren/checkmate.nvim/issues?state=open"')
@@ -166,7 +167,6 @@ local checkmate_spec = {
 
         vim.schedule(resume)
       end,
-      key = "<leader>T8",
     },
   },
 }
@@ -200,8 +200,38 @@ M.configs = {
           words = { enabled = true },
         },
       },
+      {
+        "folke/which-key.nvim",
+        event = "VeryLazy",
+        opts = {},
+        keys = {
+          {
+            "<leader>?",
+            function()
+              require("which-key").show({ global = false })
+            end,
+            desc = "Buffer Local Keymaps (which-key)",
+          },
+        },
+      },
     },
     checkmate = vim.tbl_deep_extend("force", checkmate_spec, {
+      keys = {
+        ["<leader>Tt"] = "toggle", -- legacy
+        ["<leader>Ta"] = {
+          rhs = "<cmd>Checkmate archive<CR>",
+          desc = "Archive todos",
+          modes = { "n" },
+        },
+        ["<leader>Tc"] = {
+          rhs = function()
+            require("checkmate").check()
+          end,
+          desc = "Check todo",
+          modes = { "n", "v" },
+        },
+        ["<leader>Tu"] = { "<cmd>lua require('checkmate').uncheck()<CR>", "UNCHECK TODO", { "n", "v" } },
+      },
       --[[ ui = {
         picker = function(items, opts)
           ---@type snacks.picker.ui_select


### PR DESCRIPTION
Resolves #118 
**No breaking changes**

- [x] Need to give `config.metadata.key` the same treatment? - added a {key, desc} option in addition to the current key (string) option
- [X] which-key integration (other than default → pulls 'desc' in)
  - Likely either save a more detailed integration for another PR or add a section to Wiki for which-key integration...