### PR TITLE
Feat/enable disable api

### DIFF
--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -45,8 +45,6 @@ end
 
 ---Callers should check `require("checkmate.file_matcher").should_activate_for_buffer()` before calling setup_buffer
 function M.setup_buffer(bufnr)
-  bufnr = bufnr or vim.api.nvim_get_current_buf()
-
   if not M.is_valid_buffer(bufnr) then
     return false
   end

--- a/lua/checkmate/commands_new.lua
+++ b/lua/checkmate/commands_new.lua
@@ -9,6 +9,20 @@ local commands = {}
 
 ---@type checkmate.CommandDefinition[]
 local top_commands = {
+  enable = {
+    desc = "Activate Checkmate",
+    nargs = "0",
+    handler = function()
+      require("checkmate").enable()
+    end,
+  },
+  disable = {
+    desc = "Deactivate Checkmate",
+    nargs = "0",
+    handler = function()
+      require("checkmate").disable()
+    end,
+  },
   toggle = {
     desc = "Toggle todo item under cursor or selection",
     nargs = "?",

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -294,12 +294,14 @@ end
 
 -- PUBLIC API --
 
+-- Globally disables/deactivates Checkmate for all buffers
 function M.disable()
   local cfg = require("checkmate.config")
   cfg.options.enabled = false
   M.stop()
 end
 
+-- Starts/activates Checkmate
 function M.enable()
   local cfg = require("checkmate.config")
   cfg.options.enabled = true

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -19,6 +19,8 @@ local M = {}
 
 --- internal
 
+local user_opts = {}
+
 local state = {
   initialized = false,
   running = false,
@@ -122,6 +124,8 @@ end
 ---@return boolean success
 M.setup = function(opts)
   local config = require("checkmate.config")
+
+  user_opts = opts or {}
 
   -- reload if config has changed
   if M.is_initialized() then
@@ -289,6 +293,18 @@ function M._setup_existing_markdown_buffers()
 end
 
 -- PUBLIC API --
+
+function M.disable()
+  local cfg = require("checkmate.config")
+  cfg.options.enabled = false
+  M.stop()
+end
+
+function M.enable()
+  local cfg = require("checkmate.config")
+  cfg.options.enabled = true
+  M.setup(user_opts)
+end
 
 ---Toggle todo item(s) state under cursor or in visual selection
 ---

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -212,6 +212,7 @@ describe("checkmate init and lifecycle", function()
 
       assert.is_true(checkmate.is_buffer_active(bufnr))
       assert.equal(1, checkmate.count_active_buffers())
+      assert.equal(bufnr, checkmate.get_active_buffer_list()[1])
 
       local unchecked = h.get_unchecked_marker()
       local checked = h.get_checked_marker()
@@ -233,10 +234,18 @@ describe("checkmate init and lifecycle", function()
       assert.is_false(checkmate.is_buffer_active(bufnr))
       assert.equal(0, checkmate.count_active_buffers())
 
-      print("test buffer: " .. bufnr)
-
       buf_string = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
       assert.same(content, buf_string)
+
+      checkmate.enable()
+
+      assert.is_true(checkmate.is_buffer_active(bufnr))
+      assert.equal(1, checkmate.count_active_buffers())
+      assert.equal(bufnr, checkmate.get_active_buffer_list()[1])
+
+      buf_string = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+      ok = h.verify_content_lines(buf_string, expected_lines)
+      assert.is_true(ok)
 
       finally(function()
         h.cleanup_buffer(bufnr)

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -150,10 +150,27 @@ local checkmate_spec = {
     },
     file = {
       key = "<leader>Tmf",
+      style = function(context)
+        local value = context.value
+        if value:match("%.md$") then
+          return { fg = "#fcfcb3" }
+        elseif value:match("%.lua$") then
+          return { fg = "#cafcf5" }
+        else
+          return { fg = "#dfdaf0" }
+        end
+      end,
       choices = function(_, cb)
         local project_root = vim.fs.root(0, ".git") or vim.uv.cwd() or ""
-        local items = vim.fs.find(function()
-          return true -- match all
+        local items = vim.fs.find(function(name, path)
+          if name:match("^%.") then
+            return false
+          end
+          -- skip any dir starting with "."
+          if path:match("[/\\]%.[^/\\]+") then
+            return false
+          end
+          return true
         end, { limit = math.huge, type = "file" })
         items = vim.tbl_map(function(i)
           return vim.fs.relpath(project_root, i)

--- a/tests/environments.lua
+++ b/tests/environments.lua
@@ -148,6 +148,19 @@ local checkmate_spec = {
         end)
       end,
     },
+    file = {
+      key = "<leader>Tmf",
+      choices = function(_, cb)
+        local project_root = vim.fs.root(0, ".git") or vim.uv.cwd() or ""
+        local items = vim.fs.find(function()
+          return true -- match all
+        end, { limit = math.huge, type = "file" })
+        items = vim.tbl_map(function(i)
+          return vim.fs.relpath(project_root, i)
+        end, items)
+        cb(items)
+      end,
+    },
   },
 }
 
@@ -264,6 +277,29 @@ M.configs = {
       dependencies = { "nvim-lua/plenary.nvim" },
     },
     checkmate = checkmate_spec,
+  },
+  fzf_lua = {
+    spec = {
+      { "junegunn/fzf.vim", dependencies = { "junegunn/fzf" } },
+      {
+        "ibhagwan/fzf-lua",
+        dependencies = { "nvim-tree/nvim-web-devicons" },
+        opts = {},
+      },
+    },
+    checkmate = vim.tbl_deep_extend("force", checkmate_spec, {
+      ui = {
+        picker = function(items, opts)
+          require("fzf-lua").fzf_exec(items, {
+            actions = {
+              ["default"] = function(selected)
+                opts.on_choice(selected[1])
+              end,
+            },
+          })
+        end,
+      },
+    }),
   },
   v0_8_config = {
     checkmate = vim.tbl_deep_extend("force", checkmate_spec, {


### PR DESCRIPTION
- Adds `enable` and `disable` commands and corresponding public APIs
- These will allow global (all buffers) activation and deactivation of Checkmate
- Added test to ensure that enable -> disable -> enable kept buffer in a good state