### PR TITLE
fix(api): ensure that file ends with new line

### DIFF
--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -305,6 +305,7 @@ function M.setup_autocmds(bufnr)
 
         local markdown_lines = vim.api.nvim_buf_get_lines(temp_bufnr, 0, -1, false)
 
+        -- ensure that we maintain ending new line per POSIX style
         if #markdown_lines == 0 or markdown_lines[#markdown_lines] ~= "" then
           table.insert(markdown_lines, "")
         end
@@ -312,6 +313,7 @@ function M.setup_autocmds(bufnr)
         local temp_filename = filename .. ".tmp"
 
         -- write to temp file first
+        -- we use binary mode here to ensure byte-by-byte precision and no unexpected newline behaviors
         local write_result = vim.fn.writefile(markdown_lines, temp_filename, "b")
 
         vim.api.nvim_buf_delete(temp_bufnr, { force = true })

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -305,6 +305,10 @@ function M.setup_autocmds(bufnr)
 
         local markdown_lines = vim.api.nvim_buf_get_lines(temp_bufnr, 0, -1, false)
 
+        if #markdown_lines == 0 or markdown_lines[#markdown_lines] ~= "" then
+          table.insert(markdown_lines, "")
+        end
+
         local temp_filename = filename .. ".tmp"
 
         -- write to temp file first

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -154,18 +154,13 @@ describe("API", function()
       end)
     end)
 
-    describe("BufWriteCmd compatibility", function()
+    describe("BufWriteCmd behavior", function()
       it("should handle :wa (write all modified buffers)", function()
         local bufnr1, file1 = h.setup_todo_buffer("- [ ] File 1 todo")
         local bufnr2, file2 = h.setup_todo_buffer("- [ ] File 2 todo")
 
-        vim.bo[bufnr1].eol = false
-        vim.bo[bufnr1].fixeol = false
-        vim.bo[bufnr2].eol = false
-        vim.bo[bufnr2].fixeol = false
-
         vim.api.nvim_buf_set_lines(bufnr1, 0, -1, false, { "- [ ] File 1 new" })
-        vim.api.nvim_buf_set_lines(bufnr2, 0, -1, false, { "- [ ] File 2 new" })
+        vim.api.nvim_buf_set_lines(bufnr2, 0, -1, false, { "- [ ] File 2 new", "" })
 
         assert.is_true(vim.bo[bufnr1].modified)
         assert.is_true(vim.bo[bufnr2].modified)
@@ -187,9 +182,9 @@ describe("API", function()
           error("failed read file2")
         end
 
-        -- 'write' will always leave a new line at the end (see h: eol)
-        assert.equal("- [ ] File 1 new", content1)
-        assert.equal("- [ ] File 2 new", content2)
+        -- we manually handle EOL in BufWriteCmd in binary mode so there should always be a blank last line
+        assert.equal("- [ ] File 1 new\n", content1)
+        assert.equal("- [ ] File 2 new\n", content2)
 
         finally(function()
           h.cleanup_buffer(bufnr1, file1)


### PR DESCRIPTION
This should fix #140 :)

I've tested it, and it doesn't remove the terminating newline.