### PR TITLE
Feat: Allow arbitrary todo states (not just checked or unchecked)

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,10 +736,10 @@ Individual styles can still be overriden using the `style` option and passing a 
 |----------|-------------|
 | CheckmateListMarkerUnordered | Unordered list markers, e.g. `-`,`*`, and `+`. (_Only those associated with a todo_) |
 | CheckmateListMarkerOrdered | Ordered list markers, e.g. `1.`, `2)`. (_Only those associated with a todo_) |
-| CheckmateUncheckedMarker | Unchecked todo marker, e.g. `□`. See `todo_markers` option |
+| CheckmateUncheckedMarker | Unchecked todo marker, e.g. `□`. See `todo_states` `marker` option |
 | CheckmateUncheckedMainContent | The main content of an unchecked todo (typically the first paragraph) |
 | CheckmateUncheckedAdditionalContent | Additional content for an unchecked todo (subsequent paragraphs, list items, etc.) |
-| CheckmateCheckedMarker | Checked todo marker, e.g. `✔`. See `todo_markers` option |
+| CheckmateCheckedMarker | Checked todo marker, e.g. `✔`. See `todo_states` `marker` option |
 | CheckmateCheckedMainContent | The main content of a checked todo (typically the first paragraph) |
 | CheckmateCheckedAdditionalContent | Additional content for a checked todo (subsequent paragraphs, list items, etc.) |
 | CheckmateTodoCountIndicator | The todo count indicator, e.g. `1/4`, shown on the todo line, if enabled. See `show_todo_count` option |
@@ -760,8 +760,8 @@ opts = {
 ```
 
 #### Example: Style a custom todo state
-Custom `todo_states` will be styled following the same highlight group naming convention:
-e.g. `Checkmate**State**Marker`
+[Custom todo states](#todo-states) will be styled following the same highlight group naming convention:
+e.g. `Checkmate[State]Marker`
 So, if you define a `partial` state:
 ```lua
 todo_states = {
@@ -783,16 +783,16 @@ The default states for a todo are binary, `checked` and `unchecked`. These will 
 ```lua
 todo_states = {
   checked = {
-    marker = "✅"
+    marker = "☒"
   },
   unchecked = {
-    marker = "◻️"
+    marker = "☐"
   }
 }
 ```
 
 ### Custom states
-If you would like to add additional, custom states (outside of the GFM spec), Checkmate can support this (but don't expect cross-compatibility with other Markdown programs)
+If you would like to add additional, custom states (outside of the GFM spec), Checkmate can support this (but don't assume cross-compatibility with other Markdown programs).
 
 For example, you may want to set todos as:
 - 'partial' or 'pending'
@@ -809,10 +809,18 @@ todo_states = {
   }
 }
 ```
-The `marker` is the string used in the Checkmate bufer. The `markdown` is the char used inside the Markdown task list item, e.g. `[.]`.
+`marker` is the string used in the Checkmate buffer. `markdown` is the char used inside the Markdown task list item, e.g. `[.]`.
 
 > [!TIP]
-> Be sure that the `marker` and `markdown` values are unique amongst all states, otherwise the parser won't map correctly
+> Be sure that the `marker` and `markdown` values are unique amongst all states, otherwise the parser won't map correctly.
+
+You can then cycle through a todo's states with `:Checkmate cycle_next` and `:Checkmate cycle_previous` or using the API, such as:
+```lua
+require("checkmate").cycle()
+
+-- or to toggle to a specific state
+require("checkmate").toggle("partial")
+```
 
 ## Todo count indicator
 

--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ require("checkmate").toggle("partial")
 ```
 
 ## Todo count indicator
+A todo count indicator displays the number of `checked / unchecked` todos in a hierarchy. It only counts the standard "checked" and "unchecked" states, not [custom states](#todo-states).
 
 <table>
   <tr>
@@ -877,6 +878,9 @@ todo_count_recursive = true,
 ## Smart Toggle
 
 Smart toggle provides intelligent parent-child todo state propagation. When you toggle a todo item, it can automatically update related todos based on your configuration.
+
+> [!NOTE] 
+> Smart toggle only propagates "unchecked" and "checked" states (the default/standard todo states). If [custom todo states](#todo-states) are used, they will not be included in smart toggling calculations/behavior.
 
 ### How it works
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Patterns support full Unix-style globs including `*`, `**`, `?`, `[abc]`, and `{
 - Toggle items with `:Checkmate toggle` (default: `<leader>Tt`)
 - Check items with `:Checkmate check` (default: `<leader>Tc`)
 - Uncheck items with `:Checkmate uncheck` (default: `<leader>Tu`)
+- Cycle to other [custom states](#todo-states) with `:Checkmate cycle_next` (default: `<leader>T=`) and `:Checkmate cycle_previous` (default `<leader>T-`)
 - Select multiple items in visual mode and use the same commands
 - Archive completed todos with `:Checkmate archive` (default: `<leader>Ta`)
 
@@ -778,6 +779,8 @@ styles = {
 }
 ```
 
+> State names will be converted to CamelCase when used in highlight group names. E.g. `not_planned` = `NotPlanned`
+
 ## Todo states
 The default states for a todo are binary, `checked` and `unchecked`. These will always be written to disk per the Github-flavored Markdown spec, e.g. `- [ ]` and `- [x]`. Their Checkmate buffer representation can be styled by setting the `todo_states` `marker` opt:
 ```lua
@@ -796,8 +799,8 @@ If you would like to add additional, custom states (outside of the GFM spec), Ch
 
 For example, you may want to set todos as:
 - 'partial' or 'pending'
-- 'on-hold'
-- 'not-planned'
+- 'on_hold'
+- 'not_planned'
 - etc.
 
 Just add the state to `todo_states`:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A Markdown-based todo/task plugin for Neovim.
 - Smart toggling behavior
 - Archive completed todos
 - Todo templates with LuaSnip snippet integration
+- 🆕 Custom todo states!
+  - More than just "checked" and "unchecked", e.g. "partial", "in-progress", "on-hold"
 
 > [!NOTE]
 > Check out the [Wiki](https://github.com/bngarren/checkmate.nvim/wiki) for additional documentation and recipes, including:
@@ -47,6 +49,7 @@ https://github.com/user-attachments/assets/d9b58e2c-24e2-4fd8-8d7f-557877a20218
 - [Commands](#commands)
 - [Configuration](#config)
   - [Styling](#styling)
+  - [Todo states](#todo-states)
   - [Todo counts](#todo-count-indicator)
   - [Smart toggle](#smart-toggle)
 - [Metadata](#metadata)
@@ -151,6 +154,8 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 | `archive` | Archive all checked todo items in the buffer. See api `archive()` |
 | `check` | Mark the todo item under the cursor as checked. See api `check()`|
 | `create` | Create a new todo item at the current line or line below if a todo already exists. In visual mode, convert each line to a todo item. See api `create()`|
+| `cycle_next` | Cycle a todo's state to the next available. See api `cycle()` |
+| `cycle_previous` | Cycle a todo's state to the previous. See api `cycle()` |
 | `lint` | Lint this buffer for Checkmate formatting issues. See api `lint()` |
 | `metadata add` | Add a metadata tag to the todo under the cursor or within the selection. Usage: `:Checkmate metadata add <key> [value]`. See api `add_metadata(key, value)` |
 | `metadata jump_next` | Move the cursor to the next metadata tag for the todo item under the cursor. See api `jump_next_metadata()` |
@@ -159,7 +164,7 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 | `metadata select_value` | Select a value from the 'choices' option for the metadata tag under the cursor. See api `select_metadata_value()` |
 | `metadata toggle` | Toggle a metadata tag on/off for the todo under the cursor or within the selection. Usage: `:Checkmate metadata toggle <key> [value]`. See api `toggle_metadata(key, value)` |
 | `remove_all_metadata` | Remove *all* metadata tags from the todo under the cursor or within the selection. See api `remove_all_metadata()` |
-| `toggle` | Toggle the todo item under the cursor (normal mode) or all todo items within the selection (visual mode). See api `toggle()` |
+| `toggle` | Toggle the todo item under the cursor (normal mode) or all todo items within the selection (visual mode). See api `toggle()`. This command only toggles between `unchecked` and `checked`. To change to custom states, use the api `toggle(target_state)` or the `cycle_*` commands. |
 | `uncheck` | Mark the todo item under the cursor as unchecked. See api `uncheck()` |
 
 <br>
@@ -223,7 +228,14 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 ---@field keys ( table<string, checkmate.KeymapConfig|false>| false )
 ---
 ---Characters for todo markers (checked and unchecked)
----@field todo_markers checkmate.TodoMarkers
+---@deprecated use todo_states
+---@field todo_markers? checkmate.TodoMarkers
+---
+---The states that a todo item may have
+---Default: "unchecked" and "checked"
+---Note that Github-flavored Markdown specification only includes "checked" and "unchecked". If you add additional states here, they may not work
+---in other Markdown apps without special configuration
+---@field todo_states table<string, checkmate.TodoStateDefinition>
 ---
 ---Default list item marker to be used when creating new Todo items
 ---@field default_list_marker "-" | "*" | "+"
@@ -307,8 +319,31 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 
 -----------------------------------------------------
 
+---@class checkmate.TodoStateDefinition
+---
+--- The text string used for a todo marker is expected to be 1 character length.
+--- Multiple characters _may_ work but are not currently supported and could lead to unexpected results.
+---@field marker string
+---
+--- Markdown checkbox representation
+--- For custom states, this determines how the todo state is written in Markdown syntax.
+--- Important:
+---   - Must be unique among all todo states. If two states share the same Markdown representation, there will
+---   be unpredictable behavior when parsing the Markdown into the Checkmate buffer
+---   - Not guaranteed to work in other apps/plugins as custom `[.]`, `[/]`, etc. are not standard Github-flavored Markdown
+---   - This field is ignored for default `checked` and `unchecked` states as these are always represented per Github-flavored
+--- Markdown spec, e.g. `[ ]` and `[x]`
+---@field markdown string | string[]
+---
+--- The order in which this state is cycled (lower = first)
+---@field order? number
+
+-----------------------------------------------------
+
+--- DEPRECATED v0.10
 --- The text string used for todo markers is expected to be 1 character length.
 --- Multiple characters _may_ work but are not currently supported and could lead to unexpected results.
+---@deprecated use `todo_states`
 ---@class checkmate.TodoMarkers
 ---
 ---Character used for unchecked items
@@ -530,6 +565,16 @@ local defaults = {
       desc = "Set todo item as unchecked (not done)",
       modes = { "n", "v" },
     },
+    ["<leader>T="] = {
+      rhs = "<cmd>Checkmate cycle_next<CR>",
+      desc = "Cycle todo item(s) to the next state",
+      modes = { "n", "v" },
+    },
+    ["<leader>T-"] = {
+      rhs = "<cmd>Checkmate cycle_previous<CR>",
+      desc = "Cycle todo item(s) to the previous state",
+      modes = { "n", "v" },
+    },
     ["<leader>Tn"] = {
       rhs = "<cmd>Checkmate create<CR>",
       desc = "Create todo item",
@@ -562,9 +607,16 @@ local defaults = {
     },
   },
   default_list_marker = "-",
-  todo_markers = {
-    unchecked = "□",
-    checked = "✔",
+  todo_states = {
+-- we don't need to set the `markdown` field for `unchecked` and `checked` as these can't be overriden
+    unchecked = {
+      marker = "□",
+      order = 999,
+    },
+    checked = {
+      marker = "✔",
+      order = 1,
+    },
   },
   style = {}, -- override defaults
   enter_insert_after_new = true, -- Should enter INSERT mode after `:Checkmate create` (new todo)
@@ -694,7 +746,11 @@ Individual styles can still be overriden using the `style` option and passing a 
 
 Metadata highlights are prefixed with `CheckmateMeta_` and keyed with the tag name and style.
 
-### Example: Change the checked marker to a bold green
+#### Main content versus Additional content
+Highlight groups with 'MainContent' refer to the todo item's first paragraph. 'AdditionalContent' refers to subsequent paragraphs, list items, etc.
+<img src="./assets/main-vs-additional-hl-groups.png" />
+
+#### Example: Change the checked marker to a bold green
 ```lua
 opts = {
     style = {
@@ -702,10 +758,61 @@ opts = {
     }
 }
 ```
-#### Main content versus Additional content
-Highlight groups with 'MainContent' refer to the todo item's first paragraph. 'AdditionalContent' refers to subsequent paragraphs, list items, etc.
-<img src="./assets/main-vs-additional-hl-groups.png" />
 
+#### Example: Style a custom todo state
+Custom `todo_states` will be styled following the same highlight group naming convention:
+e.g. `Checkmate**State**Marker`
+So, if you define a `partial` state:
+```lua
+todo_states = {
+  partial = {
+    -- ...
+  }
+}
+```
+You can then style it:
+```lua
+styles = {
+  CheckmatePartialMarker = { fg = "#f0fc03" }
+  CheckmatePartialMainContent = { fg = "#faffa1" }
+}
+```
+
+## Todo states
+The default states for a todo are binary, `checked` and `unchecked`. These will always be written to disk per the Github-flavored Markdown spec, e.g. `- [ ]` and `- [x]`. Their Checkmate buffer representation can be styled by setting the `todo_states` `marker` opt:
+```lua
+todo_states = {
+  checked = {
+    marker = "✅"
+  },
+  unchecked = {
+    marker = "◻️"
+  }
+}
+```
+
+### Custom states
+If you would like to add additional, custom states (outside of the GFM spec), Checkmate can support this (but don't expect cross-compatibility with other Markdown programs)
+
+For example, you may want to set todos as:
+- 'partial' or 'pending'
+- 'on-hold'
+- 'not-planned'
+- etc.
+
+Just add the state to `todo_states`:
+```lua
+todo_states = {
+  partial = {
+    marker = "⚀",
+    markdown = "."
+  }
+}
+```
+The `marker` is the string used in the Checkmate bufer. The `markdown` is the char used inside the Markdown task list item, e.g. `[.]`.
+
+> [!TIP]
+> Be sure that the `marker` and `markdown` values are unique amongst all states, otherwise the parser won't map correctly
 
 ## Todo count indicator
 
@@ -913,6 +1020,8 @@ Planned features:
 - [x] **Smart toggling** - toggle all children checked if a parent todo is checked. Toggle a parent checked if the last unchecked child is checked. _Added v0.7.0_ 
 
 - [x] **Metadata upgrade** - callbacks, async support, jump to. _Added v0.9.0_
+
+- [x] **Custom todo states** - support beyond binary "checked" and "unchecked", allowing for todos to be in custom states, e.g. pending, not-planned, on-hold, etc. _Added v0.10.0_
 
 - [ ] Sorting API - user can register custom sorting functions and keymap them so that sibling todo items can be reordered quickly. e.g. `function(todo_a, todo_b)` should return an integer, and where todo_a/todo_b is a table containing data such as checked state and metadata tag/values
 

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -677,10 +677,14 @@ function M.compute_diff_toggle(items_with_states)
     local target_state = entry.target_state
     local row = todo_item.todo_marker.position.row
 
-    local new_marker = config.options.todo_states[target_state].marker
+    local state_def = config.options.todo_states[target_state]
 
-    local hunk = make_marker_replacement_hunk(row, todo_item, new_marker)
-    table.insert(hunks, hunk)
+    if state_def and state_def.marker then
+      local new_marker = config.options.todo_states[target_state].marker
+
+      local hunk = make_marker_replacement_hunk(row, todo_item, new_marker)
+      table.insert(hunks, hunk)
+    end
   end
 
   profiler.stop("api.compute_diff_toggle")

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -33,14 +33,6 @@ local top_commands = {
     complete = { "checked", "unchecked" },
   },
 
-  create = {
-    desc = "Create a new todo item",
-    nargs = "0",
-    handler = function()
-      require("checkmate").create()
-    end,
-  },
-
   check = {
     desc = "Mark todo item as checked",
     nargs = "0",
@@ -54,6 +46,30 @@ local top_commands = {
     nargs = "0",
     handler = function()
       require("checkmate").uncheck()
+    end,
+  },
+
+  cycle_next = {
+    desc = "Cycle todo state forward",
+    nargs = "0",
+    handler = function()
+      require("checkmate").cycle()
+    end,
+  },
+
+  cycle_previous = {
+    desc = "Cycle todo state backward",
+    nargs = "0",
+    handler = function()
+      require("checkmate").cycle(true)
+    end,
+  },
+
+  create = {
+    desc = "Create a new todo item",
+    nargs = "0",
+    handler = function()
+      require("checkmate").create()
     end,
   },
 

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -157,6 +157,11 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---
 --- The order in which this state is cycled (lower = first)
 ---@field order? number
+---
+--- Optional markdown checkbox representation
+--- This field is ignored for default `checked` and `unchecked` states as these are always represented per Github-flavored
+--- Markdown spec
+---@field markdown? string | string[]
 
 -----------------------------------------------------
 
@@ -1022,6 +1027,10 @@ function M.setup(opts)
     end
 
     merge_deprecated_opts(config, opts)
+
+    -- ensure that checked and unchecked todo states always have GFM representation
+    config.todo_states.checked.markdown = { "x", "X" }
+    config.todo_states.unchecked.markdown = " "
 
     -- save user style for colorscheme updates
     M._state.user_style = config.style and vim.deepcopy(config.style) or {}

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -158,11 +158,11 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 --- Markdown checkbox representation
 --- For custom states, this determines how the todo state is written in Markdown syntax.
 --- Important:
----   - Must be unique among all todo states. If two states share the same Markdown representation, then there will
+---   - Must be unique among all todo states. If two states share the same Markdown representation, there will
 ---   be unpredictable behavior when parsing the Markdown into the Checkmate buffer
 ---   - Not guaranteed to work in other apps/plugins as custom `[.]`, `[/]`, etc. are not standard Github-flavored Markdown
 ---   - This field is ignored for default `checked` and `unchecked` states as these are always represented per Github-flavored
---- Markdown spec
+--- Markdown spec, e.g. `[ ]` and `[x]`
 ---@field markdown string | string[]
 ---
 --- The order in which this state is cycled (lower = first)
@@ -392,12 +392,12 @@ local defaults = {
       desc = "Set todo item as unchecked (not done)",
       modes = { "n", "v" },
     },
-    ["<leader>T0"] = {
+    ["<leader>T="] = {
       rhs = "<cmd>Checkmate cycle_next<CR>",
       desc = "Cycle todo item(s) to the next state",
       modes = { "n", "v" },
     },
-    ["<leader>T9"] = {
+    ["<leader>T-"] = {
       rhs = "<cmd>Checkmate cycle_previous<CR>",
       desc = "Cycle todo item(s) to the previous state",
       modes = { "n", "v" },
@@ -438,20 +438,16 @@ local defaults = {
     ---@diagnostic disable-next-line: missing-fields
     unchecked = {
       marker = "□",
-      order = 1,
+      order = 999,
       -- we don't need to set the `markdown` field as it can't be overriden
     },
     ---@diagnostic disable-next-line: missing-fields
     checked = {
       marker = "✔",
-      order = 2,
+      order = 1,
       -- we don't need to set the `markdown` field as it can't be overriden
     },
   },
-  --[[ todo_markers = {
-    unchecked = "□",
-    checked = "✔",
-  }, ]]
   style = {}, -- override defaults
   enter_insert_after_new = true, -- Should enter INSERT mode after `:Checkmate create` (new todo)
   smart_toggle = {
@@ -666,6 +662,7 @@ function M.validate_options(opts)
   end
 
   -- Validate todo_markers
+  ---@deprecated v0.10
   if opts.todo_markers ~= nil then
     ok, err = validate_type(opts.todo_markers, "table", "todo_markers", true)
     if not ok then

--- a/lua/checkmate/config.lua
+++ b/lua/checkmate/config.lua
@@ -58,6 +58,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 ---@field keys ( table<string, checkmate.KeymapConfig|false>| false )
 ---
 ---Characters for todo markers (checked and unchecked)
+---@deprecated use TodoState
 ---@field todo_markers checkmate.TodoMarkers
 ---
 ---Default list item marker to be used when creating new Todo items
@@ -144,6 +145,7 @@ M.ns_todos = vim.api.nvim_create_namespace("checkmate_todos")
 
 --- The text string used for todo markers is expected to be 1 character length.
 --- Multiple characters _may_ work but are not currently supported and could lead to unexpected results.
+---@deprecated use TodoState
 ---@class checkmate.TodoMarkers
 ---
 ---Character used for unchecked items

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -15,10 +15,7 @@ M.PRIORITY = {
 ---@param is_main_content boolean Whether this is main content or additional content
 ---@return string highlight_group The highlight group to use
 function M.get_todo_content_highlight(todo_state, is_main_content)
-  -- capitalize the state name
-  -- e.g. checked -> CheckmateCheckedMainContent
-  -- e.g. partial -> CheckmatePartialAdditionalContent
-  local state_name = todo_state:gsub("^%l", string.upper)
+  local state_name = require("checkmate.util").snake_to_camel(todo_state)
 
   if is_main_content then
     return "Checkmate" .. state_name .. "MainContent"
@@ -87,11 +84,11 @@ function M.register_highlight_groups()
 
   -- generate highlight groups for each todo state
   for state_name, _ in pairs(config.options.todo_states) do
-    local capitalized = state_name:gsub("^%l", string.upper)
+    local state_name_camel = require("checkmate.util").snake_to_camel(state_name)
 
-    local marker_group = "Checkmate" .. capitalized .. "Marker"
-    local main_content_group = "Checkmate" .. capitalized .. "MainContent"
-    local additional_content_group = "Checkmate" .. capitalized .. "AdditionalContent"
+    local marker_group = "Checkmate" .. state_name_camel .. "Marker"
+    local main_content_group = "Checkmate" .. state_name_camel .. "MainContent"
+    local additional_content_group = "Checkmate" .. state_name_camel .. "AdditionalContent"
 
     if config.options.style[marker_group] then
       highlights[marker_group] = config.options.style[marker_group]
@@ -327,8 +324,8 @@ function M.highlight_todo_marker(bufnr, todo_item)
   local marker_text = todo_item.todo_marker.text
 
   if marker_pos.col >= 0 then
-    local state_name = todo_item.state:gsub("^%l", string.upper)
-    local hl_group = "Checkmate" .. state_name .. "Marker"
+    local state_name_camel = require("checkmate.util").snake_to_camel(todo_item.state)
+    local hl_group = "Checkmate" .. state_name_camel .. "Marker"
 
     local line = M.get_buffer_line(bufnr, marker_pos.row)
     if not line then

--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -15,6 +15,9 @@ M.PRIORITY = {
 ---@param is_main_content boolean Whether this is main content or additional content
 ---@return string highlight_group The highlight group to use
 function M.get_todo_content_highlight(todo_state, is_main_content)
+  -- capitalize the state name
+  -- e.g. checked -> CheckmateCheckedMainContent
+  -- e.g. partial -> CheckmatePartialAdditionalContent
   local state_name = todo_state:gsub("^%l", string.upper)
 
   if is_main_content then

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -116,8 +116,7 @@ function M.stop()
   pcall(vim.api.nvim_del_augroup_by_name, "checkmate_highlights")
 
   local parser = require("checkmate.parser")
-  parser.todo_map_cache = {}
-  parser.clear_pattern_cache()
+  parser.clear_parser_cache()
 
   if package.loaded["checkmate.log"] then
     pcall(function()
@@ -134,7 +133,7 @@ end
 
 ---@class checkmate.Todo
 ---@field _todo_item checkmate.TodoItem internal representation
----@field state checkmate.TodoItemState
+---@field state string Todo state, e.g. "checked", "unchecked", or custom state like "pending". See config `todo_states`
 ---@field text string First line of the todo
 ---@field indent number Number of spaces before the list marker
 ---@field list_marker string List item marker, e.g. `-`, `*`, `+`
@@ -167,7 +166,7 @@ end
 ---Toggle todo item(s) state under cursor or in visual selection
 ---
 ---To set a specific todo item to a target state, use `set_todo_item`
----@param target_state? checkmate.TodoItemState Optional target state ("checked" or "unchecked")
+---@param target_state? string Optional target state ("checked" or "unchecked")
 ---@return boolean success
 function M.toggle(target_state)
   local api = require("checkmate.api")
@@ -235,7 +234,7 @@ end
 
 ---Sets a given todo item to a specific state
 ---@param todo_item checkmate.TodoItem Todo item to set state
----@param target_state checkmate.TodoItemState
+---@param target_state string Todo state, e.g. "checked", "unchecked", or a custom state like "pending"
 ---@return boolean success
 function M.set_todo_item(todo_item, target_state)
   local api = require("checkmate.api")
@@ -299,6 +298,63 @@ end
 ---@return boolean success
 function M.uncheck()
   return M.toggle("unchecked")
+end
+
+--- Cycle todo item(s) to the next or previous state
+---@param backward? boolean If true, cycle backward through states
+---@return boolean success
+function M.cycle(backward)
+  local api = require("checkmate.api")
+  local util = require("checkmate.util")
+  local transaction = require("checkmate.transaction")
+  local parser = require("checkmate.parser")
+  local highlights = require("checkmate.highlights")
+
+  local ctx = transaction.current_context()
+  if ctx then
+    -- inside a transaction, use cursor position
+    local cursor = vim.api.nvim_win_get_cursor(0)
+    local todo_item =
+      parser.get_todo_item_at_position(ctx.get_buf(), cursor[1] - 1, cursor[2], { todo_map = ctx.get_todo_map() })
+    if todo_item then
+      local next_state = api.get_next_todo_state(todo_item.state, backward)
+      ctx.add_op(api.toggle_state, { {
+        id = todo_item.id,
+        target_state = next_state,
+      } })
+    end
+    return true
+  end
+
+  local is_visual = util.is_visual_mode()
+  local bufnr = vim.api.nvim_get_current_buf()
+  local todo_items = api.collect_todo_items_from_selection(is_visual)
+
+  if #todo_items == 0 then
+    local mode_msg = is_visual and "selection" or "cursor position"
+    util.notify(string.format("No todo items found at %s", mode_msg), vim.log.levels.INFO)
+    return false
+  end
+
+  transaction.run(bufnr, function(_ctx)
+    local operations = {}
+
+    for _, item in ipairs(todo_items) do
+      local next_state = api.get_next_todo_state(item.state, backward)
+      table.insert(operations, {
+        id = item.id,
+        target_state = next_state,
+      })
+    end
+
+    if #operations > 0 then
+      _ctx.add_op(api.toggle_state, operations)
+    end
+  end, function()
+    highlights.apply_highlighting(bufnr)
+  end)
+
+  return true
 end
 
 --- Creates a new todo item

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -165,8 +165,9 @@ end
 
 ---Toggle todo item(s) state under cursor or in visual selection
 ---
----To set a specific todo item to a target state, use `set_todo_item`
----@param target_state? string Optional target state ("checked" or "unchecked")
+--- - If a `target_state` isn't passed, it will toggle between "unchecked" and "checked"
+--- - To set a _specific_ todo item to a target state, use `set_todo_item`
+---@param target_state? string Optional target state, e.g. "checked", "unchecked", etc.
 ---@return boolean success
 function M.toggle(target_state)
   local api = require("checkmate.api")

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -196,7 +196,7 @@ function M.toggle(target_state)
         ctx.add_op(api.toggle_state, {
           {
             id = todo_item.id,
-            target_state = target_state or (todo_item.state == "unchecked" and "checked" or "unchecked"),
+            target_state = target_state or (todo_item.state ~= "checked" and "checked" or "unchecked"),
           },
         })
       end
@@ -218,7 +218,7 @@ function M.toggle(target_state)
       for _, item in ipairs(todo_items) do
         table.insert(operations, {
           id = item.id,
-          target_state = target_state or (item.state == "unchecked" and "checked" or "unchecked"),
+          target_state = target_state or (item.state ~= "checked" and "checked" or "unchecked"),
         })
       end
 

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+---@deprecated use checkmate.TodoState
 ---@alias checkmate.TodoItemState "checked" | "unchecked"
 --@alias checkmate.TodoItemState "checked" | "unchecked"
 

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -696,8 +696,7 @@ function M.discover_todos(bufnr)
       local start_row = item.start_row
 
       -- get marker position
-      local todo_marker = todo_state == "checked" and config.options.todo_markers.checked
-        or config.options.todo_markers.unchecked
+      local todo_marker = config.options.todo_states[todo_state].marker
       local marker_col = 0
       local todo_marker_byte_pos = first_line:find(todo_marker, 1, true)
       if todo_marker_byte_pos then

--- a/lua/checkmate/parser/helpers.lua
+++ b/lua/checkmate/parser/helpers.lua
@@ -203,8 +203,9 @@ function M.create_markdown_checkbox_patterns(chars)
 end
 
 --- Attempts to match a GitHub-style task list checkbox (e.g. "- [ ] foo" or "1. [x] bar")
+--- Note: this will only match the GFM task list items, not custom user configurated states, e.g. "- [.]"
 --- @param line string
---- @param state? checkmate.TodoItemState
+--- @param state? string "unchecked" or "checked"
 --- @return { indent: integer, marker: string, checked: boolean, content: string, raw_checkbox: string }? result
 function M.match_markdown_checkbox(line, state)
   line = line or ""

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -121,6 +121,22 @@ function M.trim_trailing(line)
   return line:match("^(.-)%s*$")
 end
 
+---Convert a snake_case string to CamelCase
+---@param input string input in snake_case (underscores)
+---@return string result converted to CamelCase
+function M.snake_to_camel(input)
+  local s = tostring(input)
+  -- uppercase the letter/digit after each underscore, and remove the underscore
+  s = s:gsub("_([%w])", function(c)
+    return c:upper()
+  end)
+  -- uppercase first character if it's a lowercase letter
+  s = s:gsub("^([a-z])", function(c)
+    return c:upper()
+  end)
+  return s
+end
+
 --- Returns the line's leading whitespace (indentation)
 ---@param line string
 ---@return string indent

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -1848,8 +1848,8 @@ Line 2
 
       local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
 
-      local checked = config.get_defaults().todo_markers.checked
-      local unchecked = config.get_defaults().todo_markers.unchecked
+      local checked = h.get_checked_marker()
+      local unchecked = h.get_unchecked_marker()
 
       assert.matches("- " .. vim.pesc(checked) .. " Task 1", lines[3])
       assert.matches("- " .. vim.pesc(unchecked) .. " Task 2 @priority%(high%)", lines[4])

--- a/tests/checkmate/config_spec.lua
+++ b/tests/checkmate/config_spec.lua
@@ -43,8 +43,8 @@ describe("Config", function()
 
       assert.is_true(config.options.enabled)
       assert.is_true(config.options.notify)
-      assert.equal("□", config.options.todo_markers.unchecked)
-      assert.equal("✔", config.options.todo_markers.checked)
+      assert.equal("□", config.options.todo_states.unchecked.marker)
+      assert.equal("✔", config.options.todo_states.checked.marker)
       assert.equal("-", config.options.default_list_marker)
       assert.is_true(config.options.enter_insert_after_new)
 
@@ -131,16 +131,17 @@ describe("Config", function()
 
       ---@diagnostic disable-next-line: missing-fields
       checkmate.setup({
-        ---@diagnostic disable-next-line: missing-fields
-        todo_markers = {
-          -- unchecked = "□", -- this is the default
-          checked = "✅",
+        todo_states = {
+          ---@diagnostic disable-next-line: missing-fields
+          checked = {
+            marker = "✅",
+          },
         },
         default_list_marker = "+",
         enter_insert_after_new = false,
       })
 
-      assert.equal("✅", config.options.todo_markers.checked)
+      assert.equal("✅", config.options.todo_states.checked.marker)
       assert.equal("+", config.options.default_list_marker)
       assert.is_false(config.options.enter_insert_after_new)
 

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -243,14 +243,14 @@ end
 ---@return string marker
 function M.get_unchecked_marker()
   local config = require("checkmate.config")
-  return config.get_defaults().todo_markers.unchecked
+  return config.get_defaults().todo_states.unchecked.marker
 end
 
 ---Get the default checked marker from config
 ---@return string marker
 function M.get_checked_marker()
   local config = require("checkmate.config")
-  return config.get_defaults().todo_markers.checked
+  return config.get_defaults().todo_states.checked.marker
 end
 
 return M

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -1,5 +1,23 @@
 local M = {}
 
+---Get the default unchecked marker from config
+---@return string marker
+function M.get_unchecked_marker()
+  local config = require("checkmate.config")
+  return config.get_defaults().todo_states.unchecked.marker
+end
+
+---Get the default checked marker from config
+---@return string marker
+function M.get_checked_marker()
+  local config = require("checkmate.config")
+  return config.get_defaults().todo_states.checked.marker
+end
+
+function M.get_pending_marker()
+  return "℗"
+end
+
 M.DEFAULT_TEST_CONFIG = {
   metadata = {
     ---@diagnostic disable-next-line: missing-fields
@@ -7,6 +25,12 @@ M.DEFAULT_TEST_CONFIG = {
   },
   enter_insert_after_new = false,
   smart_toggle = { enabled = false },
+  todo_states = {
+    pending = {
+      marker = M.get_pending_marker(),
+      markdown = ".", -- i.e. [.]
+    },
+  },
 }
 
 --- @param content string|string[]
@@ -237,20 +261,6 @@ function M.make_selection(row1, col1, row2, col2, mode)
   vim.api.nvim_win_set_cursor(0, { row2, col2 })
 
   vim.wait(5)
-end
-
----Get the default unchecked marker from config
----@return string marker
-function M.get_unchecked_marker()
-  local config = require("checkmate.config")
-  return config.get_defaults().todo_states.unchecked.marker
-end
-
----Get the default checked marker from config
----@return string marker
-function M.get_checked_marker()
-  local config = require("checkmate.config")
-  return config.get_defaults().todo_states.checked.marker
 end
 
 return M

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -138,7 +138,7 @@ end
 ---@param x T?
 ---@return T
 function M.exists(x)
-  assert(x ~= nil, "Unexpected nil")
+  assert(x ~= nil, "Does not exist!")
   return x
 end
 

--- a/tests/checkmate/highlights_spec.lua
+++ b/tests/checkmate/highlights_spec.lua
@@ -21,8 +21,8 @@ describe("Highlights", function()
     it("should correctly highlight the todo LIST marker", function()
       local config = require("checkmate.config")
       local highlights = require("checkmate.highlights")
-      local unchecked = config.get_defaults().todo_markers.unchecked
-      local checked = config.get_defaults().todo_markers.checked
+      local unchecked = h.get_unchecked_marker()
+      local checked = h.get_checked_marker()
 
       local content = [[
 - ]] .. unchecked .. [[ Todo A 
@@ -67,7 +67,7 @@ describe("Highlights", function()
     it("should correctly highlight within-todo list markers", function()
       local config = require("checkmate.config")
       local highlights = require("checkmate.highlights")
-      local unchecked = config.get_defaults().todo_markers.unchecked
+      local unchecked = h.get_unchecked_marker()
 
       local content = [[
 - ]] .. unchecked .. [[ Todo A 
@@ -134,8 +134,8 @@ describe("Highlights", function()
     it("should correctly highlight the todo marker", function()
       local config = require("checkmate.config")
       local highlights = require("checkmate.highlights")
-      local unchecked = config.get_defaults().todo_markers.unchecked
-      local checked = config.get_defaults().todo_markers.checked
+      local unchecked = h.get_unchecked_marker()
+      local checked = h.get_checked_marker()
 
       local content = [[
 - ]] .. unchecked .. [[ Todo A 
@@ -205,8 +205,8 @@ describe("Highlights", function()
     it("should correctly highlight main and additional content", function()
       local config = require("checkmate.config")
       local highlights = require("checkmate.highlights")
-      local unchecked = config.get_defaults().todo_markers.unchecked
-      local checked = config.get_defaults().todo_markers.checked
+      local unchecked = h.get_unchecked_marker()
+      local checked = h.get_checked_marker()
 
       local content = [[
 - [ ] Todo A first line
@@ -326,7 +326,7 @@ describe("Highlights", function()
     it("should apply metadata tag highlights", function()
       local config = require("checkmate.config")
       local highlights = require("checkmate.highlights")
-      local unchecked = config.get_defaults().todo_markers.unchecked
+      local unchecked = h.get_checked_marker()
 
       local content = [[
 # Test Todo List
@@ -361,8 +361,8 @@ describe("Highlights", function()
     it("should display todo count when configured", function()
       local config = require("checkmate.config")
       local highlights = require("checkmate.highlights")
-      local unchecked = config.get_defaults().todo_markers.unchecked
-      local checked = config.get_defaults().todo_markers.checked
+      local unchecked = h.get_unchecked_marker()
+      local checked = h.get_checked_marker()
 
       config.options.show_todo_count = true
 

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -38,9 +38,13 @@ describe("checkmate init and lifecycle", function()
       local custom_config = {
         enabled = true,
         files = { "tasks.md", "*.task" },
-        todo_markers = {
-          checked = "x",
-          unchecked = "o",
+        todo_states = {
+          checked = {
+            marker = "x",
+          },
+          unchecked = {
+            marker = "o",
+          },
         },
         notify = false,
       }
@@ -53,8 +57,8 @@ describe("checkmate init and lifecycle", function()
       assert.equal(2, #config.options.files)
       assert.equal("tasks.md", config.options.files[1])
       assert.equal("*.task", config.options.files[2])
-      assert.equal("x", config.options.todo_markers.checked)
-      assert.equal("o", config.options.todo_markers.unchecked)
+      assert.equal("x", config.options.todo_states.checked.marker)
+      assert.equal("o", config.options.todo_states.unchecked.marker)
       assert.is_false(config.options.notify)
 
       checkmate.stop()

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -26,6 +26,7 @@ describe("checkmate init and lifecycle", function()
       assert.is_true(checkmate.is_running())
       local actual = vim.deepcopy(config.options)
       actual.style = {} -- to match expected because default has style = {}
+      actual.todo_markers = nil -- TODO: remove once @deprecated todo_markers is removed
       local expected = config.get_defaults()
       assert.same(expected, actual)
       checkmate.stop()

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -27,6 +27,8 @@ describe("checkmate init and lifecycle", function()
       local actual = vim.deepcopy(config.options)
       actual.style = {} -- to match expected because default has style = {}
       actual.todo_markers = nil -- TODO: remove once @deprecated todo_markers is removed
+      actual.todo_states.checked.markdown = nil -- won't be in expected/default as it is added during setup
+      actual.todo_states.unchecked.markdown = nil
       local expected = config.get_defaults()
       assert.same(expected, actual)
       checkmate.stop()

--- a/tests/checkmate/parser_helpers_spec.lua
+++ b/tests/checkmate/parser_helpers_spec.lua
@@ -375,8 +375,7 @@ describe("Parser Helpers", function()
     -- the "variants" are described in parser.convert_markdown_to_unicode() but, briefly, are used
     -- to match a checkbox at EOL like - [ ], as well as ensure a space after the checkbox when it isn't EOL
     it("should create unchecked checkbox with both variants", function()
-      local parser = require("checkmate.parser")
-      local unchecked_box = ph.create_markdown_checkbox_patterns(parser.markdown_unchecked_checkbox)
+      local unchecked_box = ph.create_markdown_checkbox_patterns(" ")
 
       local cases = {
         {
@@ -430,8 +429,7 @@ describe("Parser Helpers", function()
     end)
 
     it("should create checked checkbox with both variants", function()
-      local parser = require("checkmate.parser")
-      local checked_box = ph.create_markdown_checkbox_patterns(parser.markdown_checked_checkbox)
+      local checked_box = ph.create_markdown_checkbox_patterns({ "x", "X" })
 
       local cases = {
         {

--- a/tests/checkmate/parser_spec.lua
+++ b/tests/checkmate/parser_spec.lua
@@ -476,6 +476,13 @@ Line that should not affect parent-child relationship
   end)
 
   describe("todo item detection", function()
+    --[[ it("should return checkmate_todo_patterns", function()
+      local config = require("checkmate.config")
+      local parser = require("checkmate.parser")
+      local patterns = parser.get_checkmate_todo_patterns()
+      vim.print(config.options.todo_states)
+      vim.print(patterns)
+    end) ]]
     describe("get_todo_item_state", function()
       it("should detect unchecked todo items with default marker", function()
         local parser = require("checkmate.parser")
@@ -501,6 +508,7 @@ Line that should not affect parent-child relationship
         }
         for _, case in ipairs(cases) do
           local state = parser.get_todo_item_state(case)
+          vim.print({ case = case, state = state })
           assert.equal("checked", state)
         end
       end)

--- a/tests/checkmate/transaction_spec.lua
+++ b/tests/checkmate/transaction_spec.lua
@@ -114,7 +114,7 @@ describe("Transaction", function()
 
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     for _, line in ipairs(lines) do
-      assert.matches(config.options.todo_markers.checked, line)
+      assert.matches(config.options.todo_states.checked.marker, line)
     end
 
     api.apply_diff = original_apply_diff

--- a/tests/checkmate/util_spec.lua
+++ b/tests/checkmate/util_spec.lua
@@ -1,6 +1,28 @@
 describe("Util", function()
   local util = require("checkmate.util")
 
+  describe("string operations", function()
+    it("should convert snake case to camel case", function()
+      assert.equal("HelloWorld", util.snake_to_camel("hello_world"))
+      assert.equal("ThisIsATest", util.snake_to_camel("this_is_a_test"))
+      assert.equal("ABC", util.snake_to_camel("a_b_c"))
+      assert.equal("SnakeCASEInput", util.snake_to_camel("snake_CASE_input"))
+
+      -- preserves existing capitalization
+      assert.equal("AlreadyCamel", util.snake_to_camel("alreadyCamel"))
+      assert.equal("MixedUPAndDown", util.snake_to_camel("mixed_UP_and_down"))
+
+      -- numbers pass through
+      assert.equal("User123Name", util.snake_to_camel("user_123_name"))
+      assert.equal("GetHttp2Response", util.snake_to_camel("get_http2_response"))
+
+      -- edge‐cases
+      assert.equal("", util.snake_to_camel(""))
+      assert.equal("PrivateVariable", util.snake_to_camel("_private_variable"))
+      assert.equal("Trailing_", util.snake_to_camel("trailing_"))
+    end)
+  end)
+
   describe("util conversion functions", function()
     it("should correctly convert between byte and character positions for ASCII", function()
       local line = "- [ ] Simple task"


### PR DESCRIPTION
# Description
Support arbitrary todo states beyond the current binary checked/unchecked system
- user can define additional states via the config to achieve custom todo types:
`- ◐ This todo is pending`, or
`- ✘ No longer planned`, or
`- ⌽ On hold`

# Considerations
- existing `todo_markers` field remains unchanged for backwards compatibility and will be automatically synchronized with `todo_states` during config initialization
- `toggle()` continues to switch only between checked/unchecked states when no target_state is define, while new method `cycle(direction)` cycles through all states in order
  - can still use `toggle(target_state)` to set a todo to a specific state
  - smart toggle behavior should only propagate checked and unchecked states
- `config.styles` must allow for user extended states, following the Checkmate{State}Marker/MainContent/AdditionalContent convention

# Impact
- All changes are non-breaking with zero impact on users who don't configure additional states
- New API:
  - Commands: `cycle_next` and `cycle_previous`
  - API: `cycle()`

## Deprecations
- `checkmate.TodoMarkers` - will now be defined using config `todo_states` and `checkmate.TodoStateDefinition`
- `checkmate.TodoItemState` - will now be defined using config `todo_states` and `checkmate.TodoStateDefinition`

# Todo
- [x] Update `config` validation for TodoState