### PR TITLE
Feat/create todo update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 vendor/plenary.nvim
 consolidated.md
 tests/fixtures
-tests/environments.lua
 
 logs/
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 .PHONY: test test-file test-interactive clean
 
+# allow `make test DEBUG=1` (or any other target) to export DEBUG=1
+DEBUG ?= 0
+ifeq ($(DEBUG),1)
+export DEBUG
+endif
+
 FILE ?= $(f)
 TEST ?= $(t)
-
 BASENAME := $(basename $(notdir $(FILE)))
 
 #    - If FILE is empty, leave FILE_PATH empty.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Patterns support full Unix-style globs including `*`, `**`, `?`, `[abc]`, and `{
 
 (These will automatically convert when you leave insert mode!)
 
+Tip: You can also create nested/child todos using the `:Checkmate create_child` command/api, or the default keymap `<leader>TN`.
+
 ### 3. Manage Your Tasks
 
 - Toggle items with `:Checkmate toggle` (default: `<leader>Tt`)
@@ -158,7 +160,8 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 |--------------|-------------|
 | `archive` | Archive all checked todo items in the buffer. See api `archive()` |
 | `check` | Mark the todo item under the cursor as checked. See api `check()`|
-| `create` | Create a new todo item at the current line or line below if a todo already exists. In visual mode, convert each line to a todo item. See api `create()`|
+| `create` | Create a new todo item at the current line or line below if a todo already exists. In visual mode, convert each line to a todo item. See api `create()`. Can configure behavior via `opts` such as nesting, indentation, and the new todo's state. |
+| `create_child` | Create a new todo item below the current line and indented from the parent (+ 2 spaces). See api `create_child()` |
 | `cycle_next` | Cycle a todo's state to the next available. See api `cycle()` |
 | `cycle_previous` | Cycle a todo's state to the previous. See api `cycle()` |
 | `lint` | Lint this buffer for Checkmate formatting issues. See api `lint()` |

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -209,6 +209,17 @@ function M.setup_keymaps(bufnr)
       end
     end
   end
+
+  -- List continuation (default is enabled)
+  if config.options.list_continuation.enabled ~= false then
+    local lc = require("checkmate.list_continuation")
+    vim.keymap.set("i", "<CR>", function()
+      return lc.expr_newline(false)
+    end, { expr = true, silent = true, buffer = bufnr })
+    vim.keymap.set("i", "<S-CR>", function()
+      return lc.expr_newline(true)
+    end, { expr = true, silent = true, buffer = bufnr })
+  end
 end
 
 function M.setup_autocmds(bufnr)

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -212,12 +212,13 @@ function M.setup_keymaps(bufnr)
 
   -- List continuation (default is enabled)
   if config.options.list_continuation.enabled ~= false then
+    local eol_only = config.options.list_continuation.eol_only
     local lc = require("checkmate.list_continuation")
     vim.keymap.set("i", "<CR>", function()
-      return lc.expr_newline(false)
+      return lc.expr_newline({ nested = false, eol_only = eol_only })
     end, { expr = true, silent = true, buffer = bufnr })
     vim.keymap.set("i", "<S-CR>", function()
-      return lc.expr_newline(true)
+      return lc.expr_newline({ nested = true, eol_only = eol_only })
     end, { expr = true, silent = true, buffer = bufnr })
   end
 end

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -569,7 +569,7 @@ function M.create_todos(ctx, start_row, end_row, opts)
 
       if config.options.enter_insert_after_new then
         ctx.add_cb(function()
-          local new_row = todo_item and (todo_item.first_inline_range["end"].row + 1) or row + 1
+          local new_row = todo_item and (todo_item.range["end"].row + 1) or row + 1
           local new_line = vim.api.nvim_buf_get_lines(bufnr, new_row, new_row + 1, false)[1] or ""
           vim.api.nvim_win_set_cursor(0, { new_row + 1, #new_line })
           vim.cmd("startinsert!")
@@ -604,7 +604,7 @@ end
 
 --- Compute diff for creating or converting to todo items
 ---@param bufnr integer Buffer number
----@param row integer 0-based row that is the "origin" of the new todo. "convert" will turn the row into a todo item. "insert" will insert a new todo line (at row + 1 for a regular list item or at the end of a todo's first inline range)
+---@param row integer 0-based row that is the "origin" of the new todo. "convert" will turn the row into a todo item. "insert" will insert a new todo line (at row + 1 for a regular list item or at the end of a todo's range)
 ---@param opts? ComputeDiffCreateTodoOpts
 ---@return checkmate.TextDiffHunk[]
 function M.compute_diff_create_todo(bufnr, row, opts)
@@ -701,7 +701,7 @@ function M.compute_diff_create_todo(bufnr, row, opts)
     local new_line = indent_str .. li_marker_str .. " " .. todo_marker .. " "
 
     -- if it's a todo item on the current row, we insert below its range
-    local start_row = todo_item and (todo_item.first_inline_range["end"].row + 1) or row + 1
+    local start_row = todo_item and (todo_item.range["end"].row + 1) or row + 1
 
     return {
       {

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -75,6 +75,14 @@ local top_commands = {
     end,
   },
 
+  create_child = {
+    desc = "Create a new todo item nested under current line",
+    nargs = "0",
+    handler = function()
+      require("checkmate").create_child()
+    end,
+  },
+
   lint = {
     desc = "Lint this buffer for Checkmate formatting issues",
     nargs = "0",

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -28,11 +28,13 @@ local top_commands = {
   toggle = {
     desc = "Toggle todo item under cursor or selection",
     nargs = "?",
-    handler = function(opts)
-      -- opts.fargs[2] may be "checked" or "unchecked"
-      require("checkmate").toggle(opts.fargs[2])
+    handler = function(data)
+      local fargs = data.fargs
+      require("checkmate").toggle(fargs and fargs[2] or nil)
     end,
-    complete = { "checked", "unchecked" },
+    complete = function()
+      return require("checkmate.config").get_todo_states()
+    end,
   },
 
   check = {
@@ -69,17 +71,25 @@ local top_commands = {
 
   create = {
     desc = "Create a new todo item",
-    nargs = "0",
-    handler = function()
-      require("checkmate").create()
+    nargs = "?",
+    handler = function(data)
+      local fargs = data.fargs
+      require("checkmate").create({ state = fargs and fargs[2] or nil })
+    end,
+    complete = function()
+      return require("checkmate.config").get_todo_states()
     end,
   },
 
   create_child = {
     desc = "Create a new todo item nested under current line",
-    nargs = "0",
-    handler = function()
-      require("checkmate").create_child()
+    nargs = "?",
+    handler = function(data)
+      local fargs = data.fargs
+      require("checkmate").create_child({ state = fargs and fargs[2] or nil })
+    end,
+    complete = function()
+      return require("checkmate.config").get_todo_states()
     end,
   },
 

--- a/lua/checkmate/config/defaults.lua
+++ b/lua/checkmate/config/defaults.lua
@@ -50,6 +50,11 @@ return {
       desc = "Create todo item",
       modes = { "n", "v" },
     },
+    ["<leader>TN"] = {
+      rhs = "<cmd>Checkmate create_child<CR>",
+      desc = "Create todo item (nested)",
+      modes = { "n" },
+    },
     ["<leader>TR"] = {
       rhs = "<cmd>Checkmate remove_all_metadata<CR>",
       desc = "Remove all metadata from a todo item",

--- a/lua/checkmate/config/defaults.lua
+++ b/lua/checkmate/config/defaults.lua
@@ -97,6 +97,10 @@ return {
   },
   style = {}, -- override defaults
   enter_insert_after_new = true, -- Should enter INSERT mode after `:Checkmate create` (new todo)
+  list_continuation = {
+    enabled = true,
+    inherit_state = false,
+  },
   smart_toggle = {
     enabled = true,
     include_cycle = false,

--- a/lua/checkmate/config/defaults.lua
+++ b/lua/checkmate/config/defaults.lua
@@ -100,6 +100,7 @@ return {
   list_continuation = {
     enabled = true,
     inherit_state = false,
+    eol_only = true,
   },
   smart_toggle = {
     enabled = true,

--- a/lua/checkmate/config/init.lua
+++ b/lua/checkmate/config/init.lua
@@ -240,6 +240,11 @@ M.options = {}
 ---
 --- Default: false. If false, new todos will be "unchecked".
 ---@field inherit_state? boolean
+---
+--- If true, list continuation will only occur when the cursor is at the end of line. `<CR>` or `<S-CR>` will have default behavior when the cursor is not EOL.
+--- If false, `<CR>` or `<S-CR>` will break the line at the cursor and insert the remainder as a new todo line.
+--- Default: true.
+---@field eol_only? boolean
 
 -----------------------------------------------------
 

--- a/lua/checkmate/config/init.lua
+++ b/lua/checkmate/config/init.lua
@@ -536,4 +536,12 @@ function M.get_todo_state_type(state_name)
   return state_def and state_def.type or "inactive"
 end
 
+function M.get_todo_states()
+  local states = {}
+  for state_name in pairs(M.options.todo_states) do
+    table.insert(states, state_name)
+  end
+  return states
+end
+
 return M

--- a/lua/checkmate/config/init.lua
+++ b/lua/checkmate/config/init.lua
@@ -93,6 +93,8 @@ M.options = {}
 ---Enter insert mode after `:Checkmate create`, require("checkmate").create()
 ---@field enter_insert_after_new boolean
 ---
+---@field list_continuation checkmate.ListContinuationSettings
+---
 ---Smart toggle provides intelligent parent-child todo state propagation
 ---
 ---When you change a todo's state, it can automatically update related todos based on their
@@ -218,6 +220,26 @@ M.options = {}
 ---If false, will default to vim.ui.select
 ---If a function is passed, will use this picker implementation
 ---@field picker? checkmate.Picker
+
+-----------------------------------------------------
+
+---@class checkmate.ListContinuationSettings
+---
+--- Whether to enable list continuation behavior
+---
+--- If true, new todo (lines) will be added in INSERT mode when the cursor is at the end of line on a todo and is triggered by:
+--- - `<CR>` - this will add a sibling todo beneath the current line
+--- - `<S-CR>` - this will add a nested todo beneath the current line (+2 spaces relative to the parent)
+---
+--- Works for both raw Markdown (e.g. `- [ ]`) and Unicode style (e.g. `- ☐`) todos.
+---
+--- Default: true
+---@field enabled? boolean
+---
+--- If true, the new todo will inherit the state of the original line, i.e. it's previous sibling or its parent (if a nested todo is created)
+---
+--- Default: false. If false, new todos will be "unchecked".
+---@field inherit_state? boolean
 
 -----------------------------------------------------
 

--- a/lua/checkmate/config/validate.lua
+++ b/lua/checkmate/config/validate.lua
@@ -313,6 +313,7 @@ function M.validate_options(opts)
     if opts.list_continuation then
       validate("list_continuation.enabled", opts.list_continuation.enabled, "boolean", true)
       validate("list_continuation.inherit_state", opts.list_continuation.inherit_state, "boolean", true)
+      validate("list_continuation.eol_only", opts.list_continuation.eol_only, "boolean", true)
     end
 
     if opts.smart_toggle then

--- a/lua/checkmate/config/validate.lua
+++ b/lua/checkmate/config/validate.lua
@@ -310,6 +310,11 @@ function M.validate_options(opts)
       end
     end
 
+    if opts.list_continuation then
+      validate("list_continuation.enabled", opts.list_continuation.enabled, "boolean", true)
+      validate("list_continuation.inherit_state", opts.list_continuation.inherit_state, "boolean", true)
+    end
+
     if opts.smart_toggle then
       validate("smart_toggle.enabled", opts.smart_toggle.enabled, "boolean", true)
       validate("smart_toggle.include_cycle", opts.smart_toggle.include_cycle, "boolean", true)

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -397,7 +397,7 @@ end
 ---@class checkmate.CreateOpts
 ---@field nested? boolean Create as nested/child todo (default: false, normal mode only)
 ---@field indent? number Absolute indentation in spaces, from the start of line. Only applies when creating new todos below existing lines. When nil: inherits parent's indent for siblings, or parent's indent + 2 for nested todos.
----@field state? string Target todo state (default: "unchecked", or inherits from parent if nested). If the `state` is not defined in config `todo_states` then "unchecked" will be used.
+---@field state? string|boolean Target todo state (default: "unchecked", or inherits from parent if `true`). If the `state` is not defined in config `todo_states` then "unchecked" will be used.
 
 --- Creates a new todo item
 ---
@@ -492,6 +492,21 @@ function M.create(opts)
   end)
 
   return true
+end
+
+--- Creates a child todo under the current line
+---
+--- Attempts to indent the new todo based on the current line's indentation
+---
+--- For `opts` description see corresponding parameters in `create()` function
+---@param opts? {state?: string|boolean}
+---@return boolean
+function M.create_child(opts)
+  opts = opts or {}
+  return M.create({
+    nested = true,
+    state = opts.state,
+  })
 end
 
 --- Insert a metadata tag into a todo item(s) under the cursor or per todo in the visual selection

--- a/lua/checkmate/list_continuation.lua
+++ b/lua/checkmate/list_continuation.lua
@@ -1,6 +1,5 @@
 local util = require("checkmate.util")
 local ph = require("checkmate.parser.helpers")
-local config = require("checkmate.config")
 
 --[[
 This module provides an `expr` mapping for `<CR>` and `<S-CR>` in Insert mode to
@@ -18,25 +17,94 @@ Notes:
 
 local M = {}
 
---- @param nested boolean
+M._termcodes = {
+  cr = "",
+  -- stop the last undo block here
+  -- see :h undo-break
+  undo_break = "",
+  delete_to_eol = "",
+  -- ensure the cursor starts at col 0 before adding absolute indent
+  -- note: otherwise `\r` will put the cursor on a new line but may auto indent
+  ctrl_o0 = "",
+}
+
+-- can enable for testing
+M._disable_async = false
+
+function M._get_termcode(name)
+  if not M._termcodes[name] then
+    if name == "cr" then
+      M._termcodes[name] = vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+    elseif name == "undo_break" then
+      M._termcodes[name] = vim.api.nvim_replace_termcodes("<C-g>u", true, false, true)
+    elseif name == "delete_to_eol" then
+      M._termcodes[name] = vim.api.nvim_replace_termcodes("<C-o>D", true, false, true)
+    elseif name == "ctrl_o0" then
+      M._termcodes[name] = vim.api.nvim_replace_termcodes("<C-o>0", true, false, true)
+    end
+  end
+  return M._termcodes[name]
+end
+
+--- @param todo table
+--- @param config checkmate.Config
+--- @return string
+function M._build_checkbox_marker(todo, config)
+  if config.list_continuation.inherit_state then
+    if todo.is_markdown then
+      return todo.raw
+    else
+      return config.todo_states[todo.state].marker
+    end
+  else
+    -- don't inherit state, use default "unchecked"
+    if todo.is_markdown then
+      return string.format("[%s]", config.todo_states.unchecked.markdown)
+    else
+      return config.todo_states.unchecked.marker
+    end
+  end
+end
+
+--- This function is used to provide the `:h map-expression` when creating keymaps for Insert mode
+---
+--- It essentially checks if the current line (in insert mode) is a todo line (either Markdown or Checkmate/unicode style) and
+--- if true, returns an expression string that creates a new todo line with correct indentation and marker in an undo-friendly way
+---
+--- Default behavior is to only work when cursor is at end of line (this can be configured with `opts.eol_only`)
+--- @param opts? {nested?: boolean, eol_only?: boolean}
 --- @return string  "" to swallow the key, or "<CR>" to fall back
-function M.expr_newline(nested)
-  local _, col = unpack(vim.api.nvim_win_get_cursor(0))
+function M.expr_newline(opts)
+  opts = opts or {}
+
+  if opts.nested == nil then
+    opts.nested = false
+  end
+  if opts.eol_only == nil then
+    opts.eol_only = true
+  end
+
+  local config = require("checkmate.config")
+
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
   col = col - 1 -- convert to 0-based
 
   local line = vim.api.nvim_get_current_line()
 
+  local cursor_is_eol = util.is_end_of_line(line, col)
+
   -- only trigger if we're at EOL of a todo
-  if not util.is_end_of_line(line, col) then
-    return vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+  if opts.eol_only and not cursor_is_eol then
+    return M._get_termcode("cr")
   end
+
   local todo = ph.match_todo(line)
   if not todo then
-    return vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+    return M._get_termcode("cr")
   end
 
   -- get indent: same as parent, plus 2 spaces if nested
-  local child_indent = nested and 2 or 0
+  local child_indent = opts.nested and 2 or 0
   local indent = todo.indent + child_indent
   local indent_str = string.rep(" ", indent)
 
@@ -59,19 +127,42 @@ function M.expr_newline(nested)
     end
   end
 
-  -- stop the last undo block here
-  -- see :h undo-break
-  local undo_break = vim.api.nvim_replace_termcodes("<C-g>u", true, false, true)
-
-  -- ensure the cursor starts at col 0 before adding absolute indent
-  -- note: otherwise `\r` will put the cursor on a new line but may auto indent
-  local ctrl_o0 = vim.api.nvim_replace_termcodes("<C-o>0", true, false, true)
+  -- if <CR>/<S-CR> occurs within a line, we grab the remaining string we can append it to the new todo
+  local text_after_cursor = ""
+  if not cursor_is_eol then
+    text_after_cursor = string.sub(line, col + 2) -- +2 because col is 0-based and sub is 1-based
+    text_after_cursor = util.trim_leading(text_after_cursor)
+  end
 
   local insert_text = indent_str .. todo.list_marker .. " " .. box .. " "
+  if text_after_cursor ~= "" then
+    -- the expected cursor behavior is to end up in front of the broken text from the prev row
+    -- position the cursor in front of the text_after_cursor
+    local target_col = #insert_text
 
-  local prefix = undo_break .. "\r" .. ctrl_o0
+    if not M._disable_async then
+      M._vim.schedule(function()
+        vim.api.nvim_win_set_cursor(0, { row + 1, target_col })
+      end)
+    end
 
-  return prefix .. insert_text
+    insert_text = insert_text .. text_after_cursor
+  end
+
+  return M._build_expr(insert_text, { is_eol = cursor_is_eol })
+end
+
+function M._build_expr(text, opts)
+  opts = opts or {}
+
+  local parts = {
+    M._get_termcode("undo_break"),
+    opts.is_eol == false and M._get_termcode("delete_to_eol") or "",
+    "\r",
+    M._get_termcode("ctrl_o0"),
+    text,
+  }
+  return table.concat(parts, "")
 end
 
 return M

--- a/lua/checkmate/list_continuation.lua
+++ b/lua/checkmate/list_continuation.lua
@@ -1,0 +1,77 @@
+local util = require("checkmate.util")
+local ph = require("checkmate.parser.helpers")
+local config = require("checkmate.config")
+
+--[[
+This module provides an `expr` mapping for `<CR>` and `<S-CR>` in Insert mode to
+automatically create a new todo item below the current line:
+
+  - `<CR>`   – insert a sibling todo (same indent)  
+  - `<S-CR>` – insert a nested (child) todo (+2 spaces)
+
+Notes:
+  - Uses parser.helpers module to detects GitHub-style or Unicode checkbox lines 
+  - `inherit_state` allows "reusing" the original line state, otherwise defaults to "unchecked"
+  - Falls back to a normal newline when not on a todo  
+  - Returns a single string so the entire operation stays in one undo step
+--]]
+
+local M = {}
+
+--- @param nested boolean
+--- @return string  "" to swallow the key, or "<CR>" to fall back
+function M.expr_newline(nested)
+  local _, col = unpack(vim.api.nvim_win_get_cursor(0))
+  col = col - 1 -- convert to 0-based
+
+  local line = vim.api.nvim_get_current_line()
+
+  -- only trigger if we're at EOL of a todo
+  if not util.is_end_of_line(line, col) then
+    return vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+  end
+  local todo = ph.match_todo(line)
+  if not todo then
+    return vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+  end
+
+  -- get indent: same as parent, plus 2 spaces if nested
+  local child_indent = nested and 2 or 0
+  local indent = todo.indent + child_indent
+  local indent_str = string.rep(" ", indent)
+
+  -- todo marker
+  --  - for markdown, use raw checkbox, e.g "[ ]"
+  --  - for unicode, use the marker for that state
+  local box
+  if config.options.list_continuation.inherit_state then
+    if todo.is_markdown then
+      box = todo.raw
+    else
+      box = config.options.todo_states[todo.state].marker
+    end
+  else
+    -- don't inherit state, use default "unchecked"
+    if todo.is_markdown then
+      box = string.format("[%s]", config.options.todo_states.unchecked.markdown)
+    else
+      box = config.options.todo_states.unchecked.marker
+    end
+  end
+
+  -- stop the last undo block here
+  -- see :h undo-break
+  local undo_break = vim.api.nvim_replace_termcodes("<C-g>u", true, false, true)
+
+  -- ensure the cursor starts at col 0 before adding absolute indent
+  -- note: otherwise `\r` will put the cursor on a new line but may auto indent
+  local ctrl_o0 = vim.api.nvim_replace_termcodes("<C-o>0", true, false, true)
+
+  local insert_text = indent_str .. todo.list_marker .. " " .. box .. " "
+
+  local prefix = undo_break .. "\r" .. ctrl_o0
+
+  return prefix .. insert_text
+end
+
+return M

--- a/lua/checkmate/parser.lua
+++ b/lua/checkmate/parser.lua
@@ -92,6 +92,7 @@ local pattern_cache = {
   checkmate_todo_patterns_all_with_captures = nil,
   checkmate_todo_patterns_all_without_captures = nil,
   markdown_checkbox_patterns_by_state = {},
+  markdown_checkbox_patterns_all = nil,
 }
 
 -- Ordered according to `order` field
@@ -110,6 +111,7 @@ function M.clear_parser_cache()
     checkmate_todo_patterns_all_with_captures = nil,
     checkmate_todo_patterns_all_without_captures = nil,
     markdown_checkbox_patterns_by_state = {},
+    markdown_checkbox_patterns_all = nil,
   }
   todo_states_cache = nil
 end
@@ -189,6 +191,21 @@ function M.get_markdown_checkbox_patterns_by_state(todo_state)
   end
 
   return pattern_cache[cache_key][todo_state]
+end
+
+---@return string[] patterns
+function M.get_markdown_checkbox_patterns_all()
+  local cache_key = "markdown_checkbox_patterns_all"
+  if not pattern_cache[cache_key] then
+    local patterns = {}
+
+    for state_name, _ in pairs(config.options.todo_states) do
+      table.insert(patterns, M.get_markdown_checkbox_patterns_by_state(state_name))
+    end
+
+    pattern_cache[cache_key] = vim.iter(patterns):flatten():totable()
+  end
+  return pattern_cache[cache_key]
 end
 
 ---@return string[] patterns

--- a/lua/checkmate/parser/helpers.lua
+++ b/lua/checkmate/parser/helpers.lua
@@ -245,7 +245,7 @@ end
 
 --- Checks if a line matches a todo (either Markdown or unicode)
 ---@param line string
----@return {indent: integer, list_marker: string, state: string, is_markdown: boolean}? match
+---@return {indent: integer, list_marker: string, state: string, is_markdown: boolean, raw?: string}? match
 function M.match_todo(line)
   local parser = require("checkmate.parser")
   local util = require("checkmate.util")
@@ -278,6 +278,7 @@ function M.match_todo(line)
       list_marker = md_todo.marker,
       state = md_todo.state,
       is_markdown = true,
+      raw = md_todo.raw,
     }
   end
   return nil

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -144,6 +144,14 @@ function M.get_line_indent(line)
   return line:match("^(%s*)") or ""
 end
 
+--- Returns true if the col (0-based) is at the end of the trimmed line
+---@param line string
+---@param col integer (0-based)
+---@return boolean
+function M.is_end_of_line(line, col)
+  return col + 1 == #M.trim_trailing(line)
+end
+
 --- Escapes special characters in a string for safe use in a Lua pattern character class.
 --
 -- Use this when dynamically constructing a pattern like `[%s]` or `[-+*]`,

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -145,6 +145,7 @@ function M.get_line_indent(line)
 end
 
 --- Returns true if the col (0-based) is at the end of the trimmed line
+--- The 'end' is the position of the last character of the line
 ---@param line string
 ---@param col integer (0-based)
 ---@param opts? {include_whitespace?: boolean}
@@ -154,6 +155,29 @@ function M.is_end_of_line(line, col, opts)
   opts = opts or {}
   local line_length = opts.include_whitespace ~= false and #line or #M.trim_trailing(line)
   return col + 1 == line_length
+end
+
+--- Returns the next ordered marker (incremented)
+--- e.g. if `1.` is passed, will return `2.`
+--- If the passed string does not match an ordered list marker, will return nil
+--- Pass `restart = true` if the numbering should start at 1, i.e. for a nested list item
+---@param li_marker_str string
+---@param restart? boolean
+---@return string|nil
+function M.get_next_ordered_marker(li_marker_str, restart)
+  local num = li_marker_str:match("^(%d+)[.)]")
+  local result = nil
+  if num then
+    local delimiter = li_marker_str:match("[.)]")
+    if not restart then
+      -- same level: increment
+      result = tostring(tonumber(num) + 1) .. delimiter
+    else
+      -- nested: start from 1
+      result = "1" .. delimiter
+    end
+  end
+  return result
 end
 
 --- Escapes special characters in a string for safe use in a Lua pattern character class.

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -147,9 +147,13 @@ end
 --- Returns true if the col (0-based) is at the end of the trimmed line
 ---@param line string
 ---@param col integer (0-based)
+---@param opts? {include_whitespace?: boolean}
+--- - include_whitespace: Default is true
 ---@return boolean
-function M.is_end_of_line(line, col)
-  return col + 1 == #M.trim_trailing(line)
+function M.is_end_of_line(line, col, opts)
+  opts = opts or {}
+  local line_length = opts.include_whitespace ~= false and #line or #M.trim_trailing(line)
+  return col + 1 == line_length
 end
 
 --- Escapes special characters in a string for safe use in a Lua pattern character class.

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -576,9 +576,19 @@ function M.apply_diff(bufnr, hunks)
       and hunk.end_col == 0
       and #hunk.insert > 0
 
+    local is_line_replacement = hunk.start_col == 0
+      and hunk.end_col == 0
+      and hunk.end_row == hunk.start_row + 1
+      and #hunk.insert == 1
+
     if is_line_insertion then
+      -- insert new lines without affecting existing lines
       vim.api.nvim_buf_set_lines(bufnr, hunk.start_row, hunk.start_row, false, hunk.insert)
+    elseif is_line_replacement then
+      -- replace entire line(s)
+      vim.api.nvim_buf_set_lines(bufnr, hunk.start_row, hunk.end_row, false, hunk.insert)
     else
+      -- partial text replacement within line(s)
       vim.api.nvim_buf_set_text(bufnr, hunk.start_row, hunk.start_col, hunk.end_row, hunk.end_col, hunk.insert)
     end
   end

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -5,7 +5,12 @@ vim.env.NVIM_APPNAME = "headless"
 
 load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
-local spec = {}
+-- make sure `tests/` is on `package.path`
+local cwd = vim.fn.getcwd()
+package.path = cwd .. "/tests/?.lua;" .. cwd .. "/tests/?/init.lua;" .. package.path
+local env = require("fixtures.environments.headless")
+
+local spec = env.spec
 
 if vim.env.DEBUG == "1" then
   table.insert(spec, {

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -5,10 +5,33 @@ vim.env.NVIM_APPNAME = "headless"
 
 load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
+local spec = {}
+
+if vim.env.DEBUG == "1" then
+  table.insert(spec, {
+    "mfussenegger/nvim-dap",
+    dependencies = { "jbyuki/one-small-step-for-vimkind" },
+    lazy = false,
+    config = function()
+      local dap = require("dap")
+
+      dap.configurations.lua = {
+        {
+          type = "nlua",
+          request = "attach",
+          name = "Attach to running Neovim instance",
+        },
+      }
+
+      dap.adapters.nlua = function(callback, config)
+        callback({ type = "server", host = config.host or "127.0.0.1", port = config.port or 8086 })
+      end
+    end,
+  })
+end
+
 require("lazy.minit").busted({
-  spec = {
-    -- Plugin dependencies for testing
-  },
+  spec = spec,
   headless = {
     process = false,
     log = false,

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -5,9 +5,7 @@ vim.env.NVIM_APPNAME = "headless"
 
 load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
-local env = require("tests.fixtures.environments.headless")
-
-local spec = env.spec
+local spec = {}
 
 if vim.env.DEBUG == "1" then
   table.insert(spec, {

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -5,10 +5,7 @@ vim.env.NVIM_APPNAME = "headless"
 
 load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
--- make sure `tests/` is on `package.path`
-local cwd = vim.fn.getcwd()
-package.path = cwd .. "/tests/?.lua;" .. cwd .. "/tests/?/init.lua;" .. package.path
-local env = require("fixtures.environments.headless")
+local env = require("tests.fixtures.environments.headless")
 
 local spec = env.spec
 

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -3272,9 +3272,7 @@ Final content.
       local bufnr = h.setup_test_buffer(content)
 
       local todo_map = parser.discover_todos(bufnr)
-      local todo = h.find_todo_by_text(todo_map, "MyTask")
-      assert.is_not_nil(todo)
-      ---@cast todo checkmate.TodoItem
+      local todo = h.exists(h.find_todo_by_text(todo_map, "MyTask"))
 
       assert.equal("unchecked", todo.state)
 
@@ -3290,6 +3288,25 @@ Final content.
       assert.equal(todo.todo_marker.position.col + #unchecked, hunk.end_col)
       -- replacement should be the checked marker
       assert.same({ checked }, hunk.insert)
+
+      finally(function()
+        cm.stop()
+        h.cleanup_buffer(bufnr)
+      end)
+    end)
+
+    it("should compute correct diff hunk for inserting a todo below", function()
+      local unchecked = h.get_unchecked_marker()
+      local cm = require("checkmate")
+      cm.setup()
+
+      local content = [[
+- ]] .. unchecked .. [[ MyTask]]
+      local bufnr = h.setup_test_buffer(content)
+
+      local hunks = api.compute_diff_insert_todo_below(bufnr, 0)
+
+      vim.print(hunks)
 
       finally(function()
         cm.stop()

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -3294,24 +3294,5 @@ Final content.
         h.cleanup_buffer(bufnr)
       end)
     end)
-
-    it("should compute correct diff hunk for inserting a todo below", function()
-      local unchecked = h.get_unchecked_marker()
-      local cm = require("checkmate")
-      cm.setup()
-
-      local content = [[
-- ]] .. unchecked .. [[ MyTask]]
-      local bufnr = h.setup_test_buffer(content)
-
-      local hunks = api.compute_diff_insert_todo_below(bufnr, 0)
-
-      vim.print(hunks)
-
-      finally(function()
-        cm.stop()
-        h.cleanup_buffer(bufnr)
-      end)
-    end)
   end)
 end)

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -27,14 +27,24 @@ describe("checkmate init and lifecycle", function()
       assert.is_true(result)
       assert.is_true(checkmate.is_running())
       local actual = vim.deepcopy(config.options)
-      actual.style = {} -- to match expected because default has style = {}
+
+      -- verify config opts that were added after defaults
+      assert.same(" ", actual.todo_states.unchecked.markdown)
+      assert.same({ "x", "X" }, actual.todo_states.checked.markdown)
+      assert.equal("incomplete", actual.todo_states.unchecked.type)
+      assert.equal("complete", actual.todo_states.checked.type)
+
+      -- now remove these so we can compare the rest with defaults
+      actual.style = {} -- default has style = {}
       actual.todo_markers = nil -- TODO: remove once @deprecated todo_markers is removed
-      actual.todo_states.checked.markdown = nil -- won't be in expected/default as it is added during setup
+      actual.todo_states.checked.markdown = nil -- won't be in default (expected) as it is added during setup
       actual.todo_states.checked.type = nil
       actual.todo_states.unchecked.markdown = nil
       actual.todo_states.unchecked.type = nil
+
       local expected = config.get_defaults()
       assert.same(expected, actual)
+
       checkmate.stop()
     end)
 

--- a/tests/checkmate/list_continuation_spec.lua
+++ b/tests/checkmate/list_continuation_spec.lua
@@ -1,0 +1,151 @@
+describe("List continuation", function()
+  ---@module "tests.checkmate.helpers"
+  local h
+  ---@module "checkmate"
+  local cm
+  ---@module "checkmate.list_continuation"
+  local lc
+
+  lazy_setup(function()
+    -- suppress any echoes
+    stub(vim.api, "nvim_echo")
+  end)
+
+  lazy_teardown(function()
+    ---@diagnostic disable-next-line: undefined-field
+    vim.api.nvim_echo:revert()
+  end)
+
+  before_each(function()
+    _G.reset_state()
+
+    h = require("tests.checkmate.helpers")
+    cm = require("checkmate")
+    cm.setup(h.DEFAULT_TEST_CONFIG)
+
+    lc = require("checkmate.list_continuation")
+    lc._disable_async = true
+  end)
+
+  after_each(function()
+    cm.stop()
+    lc._disable_async = false
+  end)
+
+  local function setup_mocks(content, opts)
+    opts = opts or {}
+
+    local s_get_cursor = stub(vim.api, "nvim_win_get_cursor", function()
+      return opts.cursor_pos or { 1, 0 }
+    end)
+
+    local s_get_lines = stub(vim.api, "nvim_get_current_line", function()
+      return content or ""
+    end)
+
+    return {
+      get_cursor = s_get_cursor,
+      get_lines = s_get_lines,
+      revert = function()
+        s_get_cursor:revert()
+        s_get_lines:revert()
+      end,
+    }
+  end
+
+  describe("expr_newline()", function()
+    describe("with eol_only = true (default)", function()
+      it("should fall back to <CR> when not at end of line", function()
+        local content = "- [ ] Test"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, 3 } })
+        local result = lc.expr_newline()
+        assert.equal(lc._get_termcode("cr"), result)
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+
+      it("should create sibling todo when cursor at end of line (markdown)", function()
+        local content = "- [ ] Test"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
+        local result = lc.expr_newline()
+        assert.equal(lc._build_expr("- [ ] ", { is_eol = true }), result)
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+
+      it("should create nested todo when cursor at end of line (markdown)", function()
+        local content = "- [ ] Test"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
+        local result = lc.expr_newline({ nested = true })
+        assert.equal(lc._build_expr("  - [ ] ", { is_eol = true }), result) -- indented 2 spaces
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+
+      it("should create sibling todo when cursor at end of line (unicode)", function()
+        local unchecked = h.get_unchecked_marker()
+        local checked = h.get_checked_marker()
+        local content = "- " .. checked .. " Test"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
+        local result = lc.expr_newline()
+        assert.equal(lc._build_expr("- " .. unchecked .. " ", { is_eol = true }), result)
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+
+      it("should create nested todo when cursor at end of line (unicode)", function()
+        local unchecked = h.get_unchecked_marker()
+        local checked = h.get_checked_marker()
+        local content = "- " .. checked .. " Test"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
+        local result = lc.expr_newline({ nested = true })
+        assert.equal(lc._build_expr("  - " .. unchecked .. " ", { is_eol = true }), result) -- indented 2 spaces
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+
+      it("should respect indentation of parent", function()
+        local unchecked = h.get_unchecked_marker()
+        local checked = h.get_checked_marker()
+        local content = "  - " .. checked .. " Test" -- indented 2 spaces
+        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
+        local result = lc.expr_newline({ nested = true })
+        assert.equal(lc._build_expr("    - " .. unchecked .. " ", { is_eol = true }), result) -- indented 4 spaces
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+
+      it("should inherit state when enabled", function()
+        local config = require("checkmate.config")
+        config.options.list_continuation.inherit_state = true
+
+        local checked = h.get_checked_marker()
+        local content = "- " .. checked .. " Test"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
+        local result = lc.expr_newline()
+        assert.equal(lc._build_expr("- " .. checked .. " ", { is_eol = true }), result) -- checked is inherited from parent
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+    end)
+
+    describe("with eol_only = false", function()
+      it("should split line and carry text to next todo", function()
+        local content = "- [ ] foo bar baz"
+        local mocks = setup_mocks(content, { cursor_pos = { 1, 9 } }) -- cursor at "bar"
+        local result = lc.expr_newline({ eol_only = false })
+        assert.equal(lc._build_expr("- [ ] bar baz", { is_eol = false }), result)
+        finally(function()
+          mocks.revert()
+        end)
+      end)
+    end)
+  end)
+end)

--- a/tests/checkmate/list_continuation_spec.lua
+++ b/tests/checkmate/list_continuation_spec.lua
@@ -1,3 +1,15 @@
+--[[
+Some notes on this test suite:
+- Ideally we could open a Checkmate buffer and fire off the registered keymaps and then assert on the buffer,
+but I can't get this to work
+- So instead, we call the `expr_newline` function directly with the cursor position we want to test
+- In non-testing env, `expr_newline` uses vim.schedule to modify the buffer after the keymap handling is complete
+- In testing env, we use the `_test_mode` flag to run this synchronously instead, for simplicity
+- We use the `run_expr_newline` helper to help with mode switching and cursor positioning
+- Since `expr_newline` modifies the buffer, this will auto-convert Markdown to unicode syntax, thus all tests
+need to make assertions on the unicode form, even if it starts in Markdown...This is a limitation
+]]
+
 describe("List continuation", function()
   ---@module "tests.checkmate.helpers"
   local h
@@ -24,127 +36,276 @@ describe("List continuation", function()
     cm.setup(h.DEFAULT_TEST_CONFIG)
 
     lc = require("checkmate.list_continuation")
-    lc._disable_async = true
+    lc._test_mode = true
   end)
 
   after_each(function()
     cm.stop()
-    lc._disable_async = false
+    lc._test_mode = false
   end)
 
-  local function setup_mocks(content, opts)
-    opts = opts or {}
-
-    local s_get_cursor = stub(vim.api, "nvim_win_get_cursor", function()
-      return opts.cursor_pos or { 1, 0 }
-    end)
-
-    local s_get_lines = stub(vim.api, "nvim_get_current_line", function()
-      return content or ""
-    end)
-
-    return {
-      get_cursor = s_get_cursor,
-      get_lines = s_get_lines,
-      revert = function()
-        s_get_cursor:revert()
-        s_get_lines:revert()
-      end,
-    }
+  -- helper to run the expr_newline function that we are testing with correct cursor positioning
+  -- row: 1 indexed
+  -- col: 0 indexed position in INSERT mode. This puts the cursor between/before the corresponding pos in NORMAL mode
+  -- E.g. to insert at the EOL, col should be #line (1 after the last char) which puts the insert mode cursor after the last char
+  local function run_expr_newline(opts)
+    local row = opts.row
+    local col = opts.col
+    vim.cmd("startinsert")
+    vim.api.nvim_win_set_cursor(0, { row, col })
+    local i_row, i_col = unpack(vim.api.nvim_win_get_cursor(0))
+    local expr_opts = vim.tbl_extend("force", { cursor = { row = i_row - 1, col = i_col } }, opts.expr_opts or {})
+    lc.expr_newline(expr_opts)
+    h.ensure_normal_mode()
   end
 
   describe("expr_newline()", function()
     describe("with eol_only = true (default)", function()
       it("should fall back to <CR> when not at end of line", function()
+        local unchecked = h.get_unchecked_marker()
         local content = "- [ ] Test"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, 3 } })
-        local result = lc.expr_newline()
-        assert.equal(lc._get_termcode("cr"), result)
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = 3, expr_opts = { eol_only = true } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(1, #lines)
+        assert.equal("- " .. unchecked .. " Test", lines[1])
+
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
 
       it("should create sibling todo when cursor at end of line (markdown)", function()
+        local unchecked = h.get_unchecked_marker()
         local content = "- [ ] Test"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
-        local result = lc.expr_newline()
-        assert.equal(lc._build_expr("- [ ] ", { is_eol = true }), result)
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = false } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. unchecked .. " Test", lines[1])
+        assert.equal("- " .. unchecked .. " ", lines[2])
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
 
       it("should create nested todo when cursor at end of line (markdown)", function()
+        local unchecked = h.get_unchecked_marker()
         local content = "- [ ] Test"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
-        local result = lc.expr_newline({ nested = true })
-        assert.equal(lc._build_expr("  - [ ] ", { is_eol = true }), result) -- indented 2 spaces
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = true } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. unchecked .. " Test", lines[1])
+        assert.equal("  - " .. unchecked .. " ", lines[2]) -- indent 2 spaces
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
 
       it("should create sibling todo when cursor at end of line (unicode)", function()
         local unchecked = h.get_unchecked_marker()
-        local checked = h.get_checked_marker()
-        local content = "- " .. checked .. " Test"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
-        local result = lc.expr_newline()
-        assert.equal(lc._build_expr("- " .. unchecked .. " ", { is_eol = true }), result)
+        local content = "- " .. unchecked .. " Test"
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = false } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. unchecked .. " Test", lines[1])
+        assert.equal("- " .. unchecked .. " ", lines[2])
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
 
       it("should create nested todo when cursor at end of line (unicode)", function()
         local unchecked = h.get_unchecked_marker()
-        local checked = h.get_checked_marker()
-        local content = "- " .. checked .. " Test"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
-        local result = lc.expr_newline({ nested = true })
-        assert.equal(lc._build_expr("  - " .. unchecked .. " ", { is_eol = true }), result) -- indented 2 spaces
+        local content = "- " .. unchecked .. " Test"
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = true } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. unchecked .. " Test", lines[1])
+        assert.equal("  - " .. unchecked .. " ", lines[2]) -- indent 2 spaces
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
 
       it("should respect indentation of parent", function()
         local unchecked = h.get_unchecked_marker()
-        local checked = h.get_checked_marker()
-        local content = "  - " .. checked .. " Test" -- indented 2 spaces
-        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
-        local result = lc.expr_newline({ nested = true })
-        assert.equal(lc._build_expr("    - " .. unchecked .. " ", { is_eol = true }), result) -- indented 4 spaces
+        local content = "  - " .. unchecked .. " Test" -- parent indented 2 spaces
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = false } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("  - " .. unchecked .. " Test", lines[1])
+        assert.equal("  - " .. unchecked .. " ", lines[2]) -- indent 2 spaces (same as parent)
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
 
       it("should inherit state when enabled", function()
-        local config = require("checkmate.config")
-        config.options.list_continuation.inherit_state = true
-
         local checked = h.get_checked_marker()
         local content = "- " .. checked .. " Test"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, #content } })
-        local result = lc.expr_newline()
-        assert.equal(lc._build_expr("- " .. checked .. " ", { is_eol = true }), result) -- checked is inherited from parent
+        local config = require("checkmate.config")
+
+        config.options.list_continuation.inherit_state = true
+
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = false } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. checked .. " Test", lines[1])
+        assert.equal("- " .. checked .. " ", lines[2])
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
       end)
     end)
 
     describe("with eol_only = false", function()
-      it("should split line and carry text to next todo", function()
-        local content = "- [ ] foo bar baz"
-        local mocks = setup_mocks(content, { cursor_pos = { 1, 9 } }) -- cursor at "bar"
-        local result = lc.expr_newline({ eol_only = false })
-        assert.equal(lc._build_expr("- [ ] bar baz", { is_eol = false }), result)
+      it("should split line and carry text to new sibling todo", function()
+        local unchecked = h.get_unchecked_marker()
+        local content = "- " .. unchecked .. " foo bar baz"
+        local bufnr = h.setup_test_buffer(content)
+
+        -- position cursor after bar
+        -- this will move " baz" to the new line
+        run_expr_newline({ row = 1, col = #content - 4, expr_opts = { eol_only = false, nested = false } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. unchecked .. " foo bar", lines[1])
+        assert.equal("- " .. unchecked .. "  baz", lines[2])
         finally(function()
-          mocks.revert()
+          h.cleanup_buffer(bufnr)
         end)
+      end)
+
+      it("should split line and carry text to new nested todo", function()
+        local unchecked = h.get_unchecked_marker()
+        local content = "- " .. unchecked .. " foo bar baz"
+        local bufnr = h.setup_test_buffer(content)
+
+        -- position cursor after bar
+        -- this will move " baz" to the new line
+        run_expr_newline({ row = 1, col = #content - 4, expr_opts = { eol_only = false, nested = true } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("- " .. unchecked .. " foo bar", lines[1])
+        assert.equal("  - " .. unchecked .. "  baz", lines[2]) -- indented 2 spaces
+        finally(function()
+          h.cleanup_buffer(bufnr)
+        end)
+      end)
+    end)
+
+    describe("edge cases", function()
+      it("should handle different list markers", function()
+        local unchecked = h.get_unchecked_marker()
+        local checked = h.get_checked_marker()
+        local content = [[
+* [ ] Star
++ [x] Plus
+1. [ ] Number dot
+50) [ ] Number parenthesis]]
+        local bufnr = h.setup_test_buffer(content)
+
+        -- start at line 4
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        run_expr_newline({ row = 4, col = #lines[4], expr_opts = { eol_only = true, nested = false } })
+        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal("50) " .. unchecked .. " Number parenthesis", lines[4])
+        assert.equal("51) " .. unchecked .. " ", lines[5])
+
+        -- line 3
+        run_expr_newline({ row = 3, col = #lines[3], expr_opts = { eol_only = true, nested = false } })
+        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal("1. " .. unchecked .. " Number dot", lines[3])
+        assert.equal("2. " .. unchecked .. " ", lines[4])
+
+        -- line 2
+        run_expr_newline({ row = 2, col = #lines[2], expr_opts = { eol_only = true, nested = false } })
+        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal("+ " .. checked .. " Plus", lines[2])
+        assert.equal("+ " .. unchecked .. " ", lines[3])
+
+        -- line 1
+        run_expr_newline({ row = 1, col = #lines[1], expr_opts = { eol_only = true, nested = false } })
+        lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal("* " .. unchecked .. " Star", lines[1])
+        assert.equal("* " .. unchecked .. " ", lines[2])
+
+        finally(function()
+          h.cleanup_buffer(bufnr)
+        end)
+      end)
+
+      it("should reset ordered numbering on nested new todo", function()
+        local unchecked = h.get_unchecked_marker()
+        local content = "100. " .. unchecked .. " Todo"
+        local bufnr = h.setup_test_buffer(content)
+
+        run_expr_newline({ row = 1, col = #content, expr_opts = { eol_only = true, nested = true } })
+
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+        assert.equal(2, #lines)
+        assert.equal("100. " .. unchecked .. " Todo", lines[1])
+        -- indent the length of the preceding/parent list marker + 1 whitespace
+        assert.equal("     1. " .. unchecked .. " ", lines[2]) -- reset to 1.
+        finally(function()
+          h.cleanup_buffer(bufnr)
+        end)
+      end)
+    end)
+  end)
+
+  describe("cursor position validation", function()
+    it("should not create todo when cursor is before checkbox", function()
+      local unchecked = h.get_unchecked_marker()
+      local content = "- " .. unchecked .. " Test"
+      local bufnr = h.setup_test_buffer(content)
+
+      -- cursor at position 0 (before '-')
+      run_expr_newline({ row = 1, col = 0, expr_opts = { eol_only = false } })
+      local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.equal(1, #lines) -- no new lines
+      assert.equal(content, lines[1])
+
+      -- cursor at position 1 (on '-')
+      run_expr_newline({ row = 1, col = 1, expr_opts = { eol_only = false } })
+      lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.equal(1, #lines) -- no new lines
+
+      -- cursor at position 2 (after '-', before space)
+      run_expr_newline({ row = 1, col = 2, expr_opts = { eol_only = false } })
+      lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.equal(1, #lines) -- no new lines
+
+      -- cursor at position 3 (after '- ', before checkbox)
+      run_expr_newline({ row = 1, col = 3, expr_opts = { eol_only = false } })
+      lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+      assert.equal(1, #lines) -- Should not create new line
+
+      finally(function()
+        h.cleanup_buffer(bufnr)
       end)
     end)
   end)

--- a/tests/checkmate/parser_helpers_spec.lua
+++ b/tests/checkmate/parser_helpers_spec.lua
@@ -1,5 +1,10 @@
 describe("Parser Helpers", function()
-  local h, ph
+  ---@module "tests.checkmate.helpers"
+  local h
+  ---@module "checkmate.parser.helpers"
+  local ph
+  ---@module "checkmate"
+  local cm
 
   lazy_setup(function()
     -- Hide nvim_echo from polluting test output
@@ -16,6 +21,12 @@ describe("Parser Helpers", function()
 
     h = require("tests.checkmate.helpers")
     ph = require("checkmate.parser.helpers")
+    cm = require("checkmate")
+    cm.setup(h.DEFAULT_TEST_CONFIG)
+  end)
+
+  after_each(function()
+    cm.stop()
   end)
 
   describe("create_list_item_patterns", function()
@@ -488,6 +499,158 @@ describe("Parser Helpers", function()
 
       local result = ph.match_first(checked_box, "- [X]No space")
       assert.is_not_true(result.matched)
+    end)
+  end)
+
+  describe("match markdown checkbox", function()
+    it("should match GFM markdown todos", function()
+      local cases = {
+        {
+          line = "- [ ] Unchecked",
+          expected = {
+            indent = 0,
+            marker = "-",
+            raw = "[ ]",
+            state = "unchecked",
+          },
+        },
+        {
+          line = "  - [x] Checked",
+          expected = {
+            indent = 2,
+            marker = "-",
+            raw = "[x]",
+            state = "checked",
+          },
+        },
+        {
+          line = "    1. [X] Big Checked",
+          expected = {
+            indent = 4,
+            marker = "1.",
+            raw = "[X]",
+            state = "checked",
+          },
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local result = ph.match_markdown_checkbox(case.line)
+        assert.same(case.expected, result)
+      end
+    end)
+
+    it("should match custom state markdown todos", function()
+      -- pending state is defined in the top level `cm.setup()` with defaults
+      local cases = {
+        {
+          line = "- [.] Pending",
+          expected = {
+            indent = 0,
+            marker = "-",
+            raw = "[.]",
+            state = "pending",
+          },
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local result = ph.match_markdown_checkbox(case.line)
+        assert.same(case.expected, result)
+      end
+    end)
+
+    it("should respect opts.state and only match this state", function()
+      local cases = {
+        {
+          line = "- [x] Checked",
+          expected = {
+            indent = 0,
+            marker = "-",
+            raw = "[x]",
+            state = "checked",
+          },
+        },
+        {
+          line = "- [ ] Unchecked",
+          expected = nil,
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local result = ph.match_markdown_checkbox(case.line, { state = "checked" })
+        assert.same(case.expected, result)
+      end
+    end)
+  end)
+
+  describe("match todo", function()
+    it("should match a Checkmate todo line", function()
+      local unchecked = h.get_unchecked_marker()
+      local checked = h.get_checked_marker()
+      local pending = h.get_pending_marker()
+
+      local cases = {
+        {
+          line = "- " .. unchecked .. " Todo A",
+          expected = {
+            indent = 0,
+            list_marker = "-",
+            state = "unchecked",
+            is_markdown = false,
+          },
+        },
+        {
+          line = "* " .. checked .. " Todo B",
+          expected = {
+            indent = 0,
+            list_marker = "*",
+            state = "checked",
+            is_markdown = false,
+          },
+        },
+        {
+          line = "  1. " .. pending .. " Todo C",
+          expected = {
+            indent = 2,
+            list_marker = "1.",
+            state = "pending",
+            is_markdown = false,
+          },
+        },
+        {
+          line = "- [ ] Todo D",
+          expected = {
+            indent = 0,
+            list_marker = "-",
+            state = "unchecked",
+            is_markdown = true,
+          },
+        },
+        {
+          line = "  + [x] Todo E",
+          expected = {
+            indent = 2,
+            list_marker = "+",
+            state = "checked",
+            is_markdown = true,
+          },
+        },
+        {
+          line = "    10) [.] Todo F", --pending
+          expected = {
+            indent = 4,
+            list_marker = "10)",
+            state = "pending",
+            is_markdown = true,
+          },
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        local result = h.exists(ph.match_todo(case.line))
+        assert.same(case.expected, result)
+      end
     end)
   end)
 end)

--- a/tests/checkmate/parser_helpers_spec.lua
+++ b/tests/checkmate/parser_helpers_spec.lua
@@ -625,6 +625,7 @@ describe("Parser Helpers", function()
             list_marker = "-",
             state = "unchecked",
             is_markdown = true,
+            raw = "[ ]",
           },
         },
         {
@@ -634,6 +635,7 @@ describe("Parser Helpers", function()
             list_marker = "+",
             state = "checked",
             is_markdown = true,
+            raw = "[x]",
           },
         },
         {
@@ -643,6 +645,7 @@ describe("Parser Helpers", function()
             list_marker = "10)",
             state = "pending",
             is_markdown = true,
+            raw = "[.]",
           },
         },
       }
@@ -650,6 +653,17 @@ describe("Parser Helpers", function()
       for _, case in ipairs(cases) do
         local result = h.exists(ph.match_todo(case.line))
         assert.same(case.expected, result)
+      end
+
+      local nil_cases = {
+        "-[ ] Missing space",
+        "-  [ ] Too much space",
+        "- [#] Unknown markdown",
+        unchecked .. " No list marker",
+      }
+
+      for _, case in ipairs(nil_cases) do
+        assert.is_nil(ph.match_todo(case))
       end
     end)
   end)

--- a/tests/checkmate/util_spec.lua
+++ b/tests/checkmate/util_spec.lua
@@ -1,6 +1,21 @@
 describe("Util", function()
   local util = require("checkmate.util")
 
+  it("should determine end of line", function()
+    local cases = {
+      { line = "test", col = 3, expected = true },
+      { line = "trailing  ", col = 9, expected = false },
+      { line = "trailing  ", col = 7, expected = true },
+      { line = "  pre", col = 4, expected = true },
+    }
+    for _, case in ipairs(cases) do
+      assert.equal(
+        case.expected,
+        util.is_end_of_line(case.line, case.col),
+        string.format("'%s' end at col %d? %s", case.line, case.col, case.expected)
+      )
+    end
+  end)
   describe("string operations", function()
     it("should convert snake case to camel case", function()
       assert.equal("HelloWorld", util.snake_to_camel("hello_world"))

--- a/tests/checkmate/util_spec.lua
+++ b/tests/checkmate/util_spec.lua
@@ -2,6 +2,22 @@ describe("Util", function()
   local util = require("checkmate.util")
 
   it("should determine end of line", function()
+    -- including whitespace
+    local cases = {
+      { line = "test", col = 3, expected = true },
+      { line = "trailing  ", col = 9, expected = true },
+      { line = "trailing  ", col = 7, expected = false },
+      { line = "  pre", col = 4, expected = true },
+    }
+    for _, case in ipairs(cases) do
+      assert.equal(
+        case.expected,
+        util.is_end_of_line(case.line, case.col), -- default is to include whitespace if not `opts.include_whitespace` passed
+        string.format("'%s' end at col %d? %s", case.line, case.col, case.expected)
+      )
+    end
+
+    -- ignoring whitespace
     local cases = {
       { line = "test", col = 3, expected = true },
       { line = "trailing  ", col = 9, expected = false },
@@ -11,7 +27,7 @@ describe("Util", function()
     for _, case in ipairs(cases) do
       assert.equal(
         case.expected,
-        util.is_end_of_line(case.line, case.col),
+        util.is_end_of_line(case.line, case.col, { include_whitespace = false }),
         string.format("'%s' end at col %d? %s", case.line, case.col, case.expected)
       )
     end

--- a/tests/interactive.lua
+++ b/tests/interactive.lua
@@ -21,8 +21,44 @@ for _, m in ipairs({
 end
 
 local env_name = vim.env.TEST_ENV or "default"
+
+-- add base config to the path so we can reuse
+local cwd = vim.fn.getcwd()
+package.path = cwd .. "/tests/?.lua;" .. cwd .. "/tests/?/init.lua;" .. package.path
+local base = require("fixtures.environments.base")
+
+local ok, env = pcall(require, "fixtures.environments." .. env_name)
+if not ok then
+  vim.print(string.format("Failed to load environment '%s', loading 'base'", env_name))
+  env = {
+    spec = {},
+    checkmate = {},
+    config = {},
+  }
+  env_name = "base"
+end
+
 vim.env.LAZY_STDPATH = ".testdata"
 vim.env.NVIM_APPNAME = env_name
+
+-- base specs for all environments
+local spec = base.spec
+
+-- Include nvim-dap and related tooling
+if vim.env.DEBUG == "1" then
+  local debug_spec = require("bngarren.plugins.debug")
+  vim.list_extend(spec, { debug_spec })
+end
+
+-- Environment-specific specs
+vim.list_extend(spec, env.spec or {})
+
+-- Checkmate config
+local root = vim.fs.root(0, ".git")
+vim.list_extend(
+  spec,
+  { { dir = root, opts = vim.tbl_deep_extend("force", base.checkmate, env.checkmate) or {}, ft = "markdown" } }
+)
 
 load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
@@ -30,51 +66,22 @@ load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/ma
 dofile(vim.fs.abspath("~/.config/nvim/lua/bngarren/core/options.lua"))
 dofile(vim.fs.abspath("~/.config/nvim/lua/bngarren/core/keymaps.lua"))
 
-package.path = package.path .. ";" .. vim.fn.getcwd() .. "/tests/fixtures/?/init.lua"
--- add base config to the path so we can reuse
-package.path = package.path .. ";" .. vim.fs.normalize("~/.config/nvim/lua/?/init.lua")
-package.path = package.path .. ";" .. vim.fs.normalize("~/.config/nvim/lua/?.lua")
-local environments = require("environments")
-local env = environments[env_name]
-
--- base specs for all environments
-local spec = {
-  { dir = vim.uv.cwd(), opts = env.checkmate or {}, ft = "markdown" },
-  {
-    "mason-org/mason.nvim",
-    opts = {},
-  },
-  -- Menu
-  { "nvzone/volt", lazy = true },
-  { "nvzone/menu", lazy = true },
-}
-
--- Include nvim-dap and related tooling
-local debug_spec = require("bngarren.plugins.debug")
-vim.list_extend(spec, { debug_spec })
-
--- environment-specific specs
-vim.list_extend(spec, env.spec or {})
-
 require("lazy.minit").repro({
   spec = spec,
 })
+
+-- Post setup
+if base.config and type(base.config) == "function" then
+  vim.schedule(function()
+    base.config()
+  end)
+end
 
 if env.config and type(env.config) == "function" then
   vim.schedule(function()
     env.config()
   end)
 end
-
--- local ok, err = pcall(function()
---   require("osv").launch({ port = 8086 })
--- end)
--- if not ok then
---   vim.print(err)
--- else
---   vim.print("Debugger started")
---   vim.ui.select({ "y", "n" }, {}, function(choice) end)
--- end
 
 if env_name == "demo" then
   vim.cmd("edit tests/fixtures/demo.todo.md")

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -8,6 +8,19 @@ vim.g.loaded_logiPat = 1
 vim.g.loaded_rrhelper = 1
 vim.g.loaded_netrwPlugin = 1
 
+-- DEBUG enable
+if vim.env.DEBUG == "1" then
+  local ok, res = pcall(function()
+    -- blocking: will freeze the instance until a client is connected
+    require("osv").launch({ host = "127.0.0.1", port = 8086, blocking = true })
+  end)
+  if not ok then
+    vim.notify("Failed to launch debug. " .. tostring(res))
+  else
+    print("DAP listening on 127.0.0.1:8086 – waiting for client to attach…")
+  end
+end
+
 -- This function can be called by tests to reset the state between test runs
 ---@param close_buffers boolean? Closes all buffers (default true)
 _G.reset_state = function(close_buffers)


### PR DESCRIPTION
# Features
## Create child/nested todos

Adds new functionality to the `create` todo API via an `opts` parameter:
- `nested`: allows for creating child/nested todo items based on the current line's indentation
- `indent`: allows specifying the absolute indentation of the new todo (overrides)
- `state`: allow specifying the target state of the new todo (default is "unchecked"). If `true` is passed, the new todo will try to match the parent's state (if the new todo is a child)

Adds a convenience function: `create_child`

## List continuation for todo lines

Automatically create new todo lines in insert mode when <CR> or <S-CR> (nested) is entered when the cursor is at the end of an existing todo line