### PR TITLE
feat: add `remove` API that converts todo lines back to regular text

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 | `metadata remove` | Remove a specific metadata tag from the todo under the cursor or within the selection. Usage: `:Checkmate metadata remove <key>`. See api `remove_metadata(key)` |
 | `metadata select_value` | Select a value from the 'choices' option for the metadata tag under the cursor. See api `select_metadata_value()` |
 | `metadata toggle` | Toggle a metadata tag on/off for the todo under the cursor or within the selection. Usage: `:Checkmate metadata toggle <key> [value]`. See api `toggle_metadata(key, value)` |
+| `remove` | Convert a todo line back to regular text. See api `remove(opts)`. By default, will preserve the list item marker and remove any metadata. This can be configured via `opts`.
 | `remove_all_metadata` | Remove *all* metadata tags from the todo under the cursor or within the selection. See api `remove_all_metadata()` |
 | `toggle` | Toggle the todo item under the cursor (normal mode) or all todo items within the selection (visual mode). See api `toggle()`. This command only toggles between `unchecked` and `checked`. To change to custom states, use the api `toggle(target_state)` or the `cycle_*` commands. |
 | `uncheck` | Mark the todo item under the cursor as unchecked. See api `uncheck()` |
@@ -657,6 +658,11 @@ return {
     ["<leader>Tn"] = {
       rhs = "<cmd>Checkmate create<CR>",
       desc = "Create todo item",
+      modes = { "n", "v" },
+    },
+    ["<leader>Tr"] = {
+      rhs = "<cmd>Checkmate remove<CR>",
+      desc = "Remove todo marker (convert to text)",
       modes = { "n", "v" },
     },
     ["<leader>TR"] = {

--- a/lua/checkmate/commands.lua
+++ b/lua/checkmate/commands.lua
@@ -75,6 +75,14 @@ local top_commands = {
     end,
   },
 
+  remove = {
+    desc = "Convert a todo item back to a regular list item",
+    nargs = "0",
+    handler = function()
+      require("checkmate").remove()
+    end,
+  },
+
   lint = {
     desc = "Lint this buffer for Checkmate formatting issues",
     nargs = "0",

--- a/lua/checkmate/config/defaults.lua
+++ b/lua/checkmate/config/defaults.lua
@@ -50,6 +50,11 @@ return {
       desc = "Create todo item",
       modes = { "n", "v" },
     },
+    ["<leader>Tr"] = {
+      rhs = "<cmd>Checkmate remove<CR>",
+      desc = "Remove todo marker (convert to text)",
+      modes = { "n", "v" },
+    },
     ["<leader>TR"] = {
       rhs = "<cmd>Checkmate remove_all_metadata<CR>",
       desc = "Remove all metadata from a todo item",

--- a/lua/checkmate/lib/range.lua
+++ b/lua/checkmate/lib/range.lua
@@ -11,6 +11,14 @@ function M.new(start_pos, end_pos)
   return setmetatable({ start = start_pos, ["end"] = end_pos }, M)
 end
 
+---Returns a checkmate.Range from a TSNode:range
+---@param node TSNode
+---@return checkmate.Range
+function M.range_from_tsnode(node)
+  local sr, sc, er, ec = node:range()
+  return M.new({ row = sr, col = sc }, { row = er, col = ec })
+end
+
 ---Returns true if (row, col) is within [start, end], inclusive.
 ---May pass either (row, col) or a position table {row=…, col=…}.
 ---@param self checkmate.Range

--- a/lua/checkmate/transaction.lua
+++ b/lua/checkmate/transaction.lua
@@ -43,7 +43,7 @@ local util = require("checkmate.util")
 ---@field get_todo_by_id fun(id: integer): checkmate.TodoItem?
 ---@field get_todo_by_row fun(row: integer, root_only?: boolean): checkmate.TodoItem?
 ---@field add_op fun(fn: function, ...)
----@field add_cb fun(fn: function, ...)
+---@field add_cb fun(fn: fun(ctx: checkmate.TransactionContext, ...), ...)
 ---@field get_buf fun(): integer Returns the buffer
 
 M._states = {} -- bufnr -> state
@@ -66,7 +66,7 @@ end
 
 --- Starts a transaction for a buffer
 ---@param bufnr number Buffer number
----@param entry_fn function Function to start the transaction
+---@param entry_fn fun(ctx: checkmate.TransactionContext) Function to start the transaction
 ---@param post_fn function? Function to run after transaction completes
 function M.run(bufnr, entry_fn, post_fn)
   assert(not M._states[bufnr], "Nested transactions are not supported for buffer " .. bufnr)

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -285,4 +285,33 @@ function M.find_cursor_after_text(line, text)
   return #prefix + #text
 end
 
+---@param opts? table
+--- - indent: integer|string Indent string (whitespace) or number of spaces
+--- - list_marker: string
+--- - state: string Todo state, e.g. "unchecked" (default), "checked", "pending"
+--- - text: string Text after the todo marker + 1 space
+function M.todo_line(opts)
+  opts = opts or {}
+  local m = {
+    unchecked = M.get_unchecked_marker(),
+    checked = M.get_checked_marker(),
+    pending = M.get_pending_marker(),
+  }
+  local indent_str = ""
+  if opts.indent then
+    if type(opts.indent) == "number" then
+      indent_str = string.rep(" ", opts.indent)
+    elseif type(opts.indent) == "string" then
+      indent_str = opts.indent
+    end
+  end
+  ---@cast indent_str string
+  local marker = opts.list_marker or require("checkmate.config").get_defaults().default_list_marker
+  local state = opts.state or "unchecked"
+  local text = opts.text or ""
+
+  local state_marker = m[state] or m.unchecked
+  return indent_str .. marker .. " " .. state_marker .. " " .. text
+end
+
 return M


### PR DESCRIPTION
- Adds new `remove()` api and corresponding `:Checkmate remove` command
  - Converts a todo line back to regular text (removes the todo marker)
  - Works in normal mode (under cursor) or visual mode (all todos in selection)
  - Default behavior is to preserve the list item marker and remove any metadata. This can be configured via `opts`.

Addresses #171 