### PR TITLE
Fix indexing and archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,11 +1009,13 @@ For in-depth guide and recipes for custom metadata, see the [Wiki](https://githu
 <a id="archiving"><a/>
 
 # ☑️ Archiving
-Allows you to easily reorganize the buffer by moving all checked/completed todo items to a Markdown section beneath all other content. The unchecked todos are reorganized up top and spacing is adjusted.
+Allows you to easily reorganize the buffer by moving all **completed** todo items to a Markdown section beneath all other content. The remaining unchecked/incomplete todos are reorganized up top and spacing is adjusted.
+
+Archiving collects all todos with the "completed" [state type](#state-types), which includes the default "checked" state, but possibly others based on custom todo states.
 
 See `Checkmate archive` command or `require("checkmate").archive()`
 
-> Current behavior (could be adjusted in the future): a checked todo item that is nested under an unchecked parent will not be archived. This prevents 'orphan' todos being separated from their parents. Similarly, a checked parent todo will carry all nested todos (checked and unchecked) when archived.
+> Current behavior (could be adjusted in the future): a completed todo item that is nested under an incomplete parent will not be archived. This prevents 'orphan' todos being separated from their parents. Similarly, a completed parent todo will carry all nested todos (completed and incomplete) when archived.
 
 #### Heading
 By default, a Markdown level 2 header (##) section named "**Archive**" is used. You can configure the archive section heading via `config.archive.heading`

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -1732,7 +1732,7 @@ function M.archive_todos(opts)
       and todo.range.start.row > archive_start_row
       and todo.range["end"].row <= (archive_end_row or -1)
 
-    if not in_arch and todo.state == "checked" and not todo.parent_id and not todos_to_archive[id] then
+    if not in_arch and todo.state_type == "complete" and not todo.parent_id and not todos_to_archive[id] then
       -- mark root
       todos_to_archive[id] = true
       archived_root_cnt = archived_root_cnt + 1

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -711,9 +711,9 @@ end
 function M.get_todo(opts)
   opts = opts or {}
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
-  local row = opts.row or vim.api.nvim_win_get_cursor(0)[1]
+  local row = opts.row or vim.api.nvim_win_get_cursor(0)[1] - 1
 
-  local todo = require("checkmate.parser").get_todo_item_at_position(bufnr, row - 1, 0)
+  local todo = require("checkmate.parser").get_todo_item_at_position(bufnr, row, 0)
   if not todo then
     return nil
   end

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -713,7 +713,7 @@ function M.get_todo(opts)
   local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
   local row = opts.row or vim.api.nvim_win_get_cursor(0)[1]
 
-  local todo = require("checkmate.parser").get_todo_item_at_position(bufnr, row, 0)
+  local todo = require("checkmate.parser").get_todo_item_at_position(bufnr, row - 1, 0)
   if not todo then
     return nil
   end

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -2104,6 +2104,10 @@ Regular text line
 
       assert.same(todo1._todo_item, todo2.get_parent()._todo_item)
 
+      -- make sure it works with cursor pos (not passing a row)
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+      todo1 = h.exists(cm.get_todo({ bufnr = bufnr }))
+
       finally(function()
         cm.stop()
         h.cleanup_buffer(bufnr)


### PR DESCRIPTION
This PR solves two issues:

### 1-index row to 0-index row for `get_todo_item_at_position`

`get_todo_item_at_position` requires 0-indexed row, while `nvim_win_get_cursor` gives a **1-indexed** row.

### archive completed todos (not just `"checked"` ones)

When a todo is complete (when `todo.state_type == "complete"`), it should be archived. This is relevant when you have other todo states (such as cancelled) and you set the `type` to `complete`.