### PR TITLE
test: add regression test for off-by-one error in get_todo

### DIFF
--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -2797,6 +2797,10 @@ Some other content]]
       local todo = require("checkmate").get_todo({ bufnr = bufnr })
       assert.is_nil(todo)
 
+      -- make sure it works with cursor pos (not passing a row)
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+      todo1 = h.exists(cm.get_todo({ bufnr = bufnr }))
+
       finally(function()
         h.cleanup_buffer(bufnr)
       end)


### PR DESCRIPTION
Bug on main that is identified by #183. had already been fixed on develop by #174.

We add a regression test case in this PR though