### PR TITLE
fix!: changes intended behavior of `archive` to include all "completed" state type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1078,11 +1078,13 @@ For in-depth guide and recipes for custom metadata, see the [Wiki](https://githu
 <a id="archiving"><a/>
 
 # ☑️ Archiving
-Allows you to easily reorganize the buffer by moving all checked/completed todo items to a Markdown section beneath all other content. The unchecked todos are reorganized up top and spacing is adjusted.
+Allows you to easily reorganize the buffer by moving all **completed** todo items to a Markdown section beneath all other content. The remaining unchecked/incomplete todos are reorganized up top and spacing is adjusted.
+
+Archiving collects all todos with the "completed" [state type](#state-types), which includes the default "checked" state, but possibly others based on custom todo states.
 
 See `Checkmate archive` command or `require("checkmate").archive()`
 
-> Current behavior (could be adjusted in the future): a checked todo item that is nested under an unchecked parent will not be archived. This prevents 'orphan' todos being separated from their parents. Similarly, a checked parent todo will carry all nested todos (checked and unchecked) when archived.
+> Current behavior (could be adjusted in the future): a completed todo item that is nested under an incomplete parent will not be archived. This prevents 'orphan' todos being separated from their parents. Similarly, a completed parent todo will carry all nested todos (completed and incomplete) when archived.
 
 #### Heading
 By default, a Markdown level 2 header (##) section named "**Archive**" is used. You can configure the archive section heading via `config.archive.heading`

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -2269,7 +2269,7 @@ function M.archive_todos(opts)
       and todo.range.start.row > archive_start_row
       and todo.range["end"].row <= (archive_end_row or -1)
 
-    if not in_arch and todo.state == "checked" and not todo.parent_id and not todos_to_archive[id] then
+    if not in_arch and todo.state_type == "complete" and not todo.parent_id and not todos_to_archive[id] then
       -- mark root
       todos_to_archive[id] = true
       archived_root_cnt = archived_root_cnt + 1


### PR DESCRIPTION
Split from #183 

Previously `archive` would only collected "checked" todos. When we added custom todo state functionality, we should have updated archive to work on any todo state that has a "completed" state type

This should release as a **BREAKING** change since it alters the expected behavior of public API