### PR TITLE
fix(highlights): adds nil check to Normal group 'fg' to fix #196

### DIFF
--- a/lua/checkmate/highlights.lua
+++ b/lua/checkmate/highlights.lua
@@ -324,7 +324,7 @@ end
 
 function M.register_highlight_groups()
   local function normal_fg_or_nil()
-    local normal_exists = vim.fn.hlexists("Normal")
+    local normal_exists = vim.fn.hlexists("Normal") == 1
     if not normal_exists then
       log.fmt_warn("[highlights/register_highlight_groups] Missing 'Normal' hl. ")
       return nil


### PR DESCRIPTION
I can't reproduce #196 yet but seems related to 'Normal' hl group possibly being undefined when we try to use it's "fg" color.

- Try a nil check before using Normal's "fg" 