### PR TITLE
Fix bug in `keys` config, unintentional merge, duplicate keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ https://github.com/user-attachments/assets/d5fa2fc8-085a-4cee-9763-a392d543347e
 - [Usage](#usage)
 - [Commands](#commands)
 - [Configuration](#config)
+  - [Keymaps](#keymapping)
   - [Styling](#styling)
   - [Todo states](#todo-states)
   - [Todo counts](#todo-count-indicator)
@@ -181,7 +182,7 @@ The Checkmate buffer is **saved as regular Markdown** which means it's compatibl
 
 # ☑️ Config
 
-For config definitions/annotations, see [here](https://github.com/bngarren/checkmate.nvim/blob/1b91021affa076b78b885d3ea9ac4f7ae50d1135/lua/checkmate/config/init.lua#L34).
+For config definitions/annotations, see [here](https://github.com/bngarren/checkmate.nvim/blob/main/lua/checkmate/config/init.lua#L34).
 
 ## Defaults
 ```lua
@@ -383,6 +384,8 @@ return {
 
 ## Keymapping
 Default keymaps can be disabled by setting `keys = false`.
+
+The `keys` table overrides the defaults (does not merge). If you want some custom and some defaults, you need to copy the defaults into your own `keys` table.
 
 Keymaps should be defined as a dict-like table or a sequence of `{rhs, desc?, modes?}`.
 

--- a/lua/checkmate/api.lua
+++ b/lua/checkmate/api.lua
@@ -144,19 +144,7 @@ function M.setup_keymaps(bufnr)
     vim.keymap.set(mode, lhs, rhs, opts)
   end
 
-  local has_wk, wk = pcall(require, "which-key")
-
-  -- TODO: need further which-key integration
-  if has_wk then
-    wk.add({
-      "<leader>T",
-      buffer = bufnr,
-      group = "Checkmate [T]odos",
-      icon = "⊡",
-    })
-  end
-
-  bl:set("keyamps", {})
+  bl:set("keymaps", {})
 
   local DEFAULT_DESC = "Checkmate <unnamed>"
   local DEFAULT_MODES = { "n" }

--- a/tests/checkmate/config_spec.lua
+++ b/tests/checkmate/config_spec.lua
@@ -156,6 +156,29 @@ describe("Config", function()
       checkmate.stop()
     end)
 
+    it("should not duplicate user configured + default `keys`", function()
+      local checkmate = require("checkmate")
+
+      ---@diagnostic disable-next-line: missing-fields
+      checkmate.setup({
+        -- overwrite the keys
+        keys = {
+          ["<leader>Ct"] = {
+            rhs = "<cmd>Checkmate toggle<CR>",
+            desc = "Toggle todo item",
+            modes = { "n", "v" },
+          },
+        },
+      })
+
+      local config = require("checkmate.config")
+
+      assert.equal(1, vim.tbl_count(config.options.keys))
+      assert.is_true(vim.list_contains(vim.tbl_keys(config.options.keys), "<leader>Ct"))
+
+      checkmate.stop()
+    end)
+
     describe("style merging", function()
       local theme
       local orig_theme

--- a/tests/interactive.lua
+++ b/tests/interactive.lua
@@ -63,8 +63,7 @@ vim.list_extend(
 assert(loadfile("tests/lazy_bootstrap.lua"))()
 
 -- setup vim
-dofile(vim.fs.abspath("~/.config/nvim/lua/bngarren/core/options.lua"))
-dofile(vim.fs.abspath("~/.config/nvim/lua/bngarren/core/keymaps.lua"))
+dofile(vim.fs.abspath("~/.config/nvim/lua/bngarren/core/init.lua"))
 
 require("lazy.minit").repro({
   spec = spec,


### PR DESCRIPTION
Resolves #201
Since `keys` are keyed by unique strings (lhs), merging will often duplicate. This is changed to overwrite completely.

BREAKING CHANGE: `keys` are no longer merged with defaults. If custom keys + defaults are desired, you must explicitly copy the defaults into your `keys` table.