### PR TITLE
Feat/allow position opt in create

### DIFF
--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -698,7 +698,7 @@ Some other content]]
         })
       end)
 
-      it("should apply visual mode options", function()
+      it("should apply visual mode options correctly", function()
         local lines = { "Line 1", "Line 2" }
 
         -- target_state
@@ -734,6 +734,20 @@ Some other content]]
           expected = {
             todo_line({ text = "Replaced" }),
             todo_line({ text = "Replaced" }),
+          },
+        })
+
+        -- using position
+        -- this should make it behave like normal mode, creating a new todo above without any line conversion
+        test_create_scenario({
+          name = "use position to create new todo",
+          lines = lines,
+          selection = { 1, 0, 2, 0, "V" },
+          create_opts = { position = "above", content = "Test" },
+          expected = {
+            todo_line({ text = "Test" }),
+            "Line 1",
+            "Line 2",
           },
         })
       end)


### PR DESCRIPTION
**Current behavior**: calling `create()` in visual mode ignores certain opts like `position` as it was originally designed to simply convert non-todo lines in the selection. However, some use cases may benefit from "inserting" a new todo above or below the selection in visual mode.

**New behavior**: `create` handles the same opts regardless of mode. The per-mode behavior is detailed in the public API. Notably, in visual mode, if a `position` opt is passed (e.g. "above" or "below"), it will create a new todo above or below the selection, similar to normal mode. It does not convert any of the selected non-todo lines in this case.

_Breaking_ because it changes the documented behavior of public API, though this is unlikely to affect most users. This change makes the visual mode handling more intuitive when passing a `position` opt.