### PR TITLE
feat: add an `update_metadata` API

### DIFF
--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -250,6 +250,7 @@ function M.get_todo_at_cursor(bufnr)
 end
 
 --- Create a visual selection from (row1, col1) to (row2, col2)
+--- 1 based rows, 0 based col
 --- @param row1 integer Start row (1-based)
 --- @param col1 integer Start column (0-based)
 --- @param row2 integer End row (1-based)


### PR DESCRIPTION
`update_metadata` updates existing metadata values but does not create if they don't already exist. It's essentially a wrapper over the add_metadata functionality.

For upsert (add or update) behavior, `add_metadata` should be used.