### PR TITLE
fix(api): allow limited operations on undefined metadata

### DIFF
--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -1527,8 +1527,8 @@ function H.ensure_metadata_exists(metadata_name)
   local meta_mod = require("checkmate.metadata")
   local log = require("checkmate.log")
 
-  metadata_name = meta_mod.get_canonical_name(metadata_name) or ""
-  if #metadata_name == 0 then
+  local canonical = meta_mod.get_canonical_name(metadata_name)
+  if not canonical then
     log.fmt_warn(
       "[main] Metadata with name '%s' does not exist. Is it defined in the `config.metadata`?",
       metadata_name

--- a/lua/checkmate/metadata/init.lua
+++ b/lua/checkmate/metadata/init.lua
@@ -13,7 +13,7 @@ M._deprecation_msg_shown = false
 ---@return checkmate.MetadataContext
 function M.create_context(todo_item, meta_name, value, bufnr)
   local todo = require("checkmate.util").build_todo(todo_item)
-  local name = M.get_canonical_name(meta_name)
+  local name = M.get_canonical_name(meta_name) or meta_name
   return {
     value = value,
     name = name,

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -410,7 +410,7 @@ end
 ---
 ---@field action fun(cm: Checkmate, ctx?: any)
 ---@field expected? string[] Expected buffer lines after action
----@field assert? fun(bufnr: integer, lines: string[], ctx?: any) Custom assertion function
+---@field assert? fun(bufnr: integer, lines: string[], ctx?: {buffer: integer, cm: Checkmate}) Custom assertion function
 ---@field wait_ms? integer Duration to wait after action before assertions (default 0 ms)
 ---@field skip? boolean Skip this test case
 ---@field only? boolean Run only this test case
@@ -484,6 +484,7 @@ function M.run_test_cases(test_cases, opts)
     end
 
     ctx.buffer = ctx.buffer or bufnr
+    ctx.cm = ctx.cm or cm
 
     tc.action(cm, ctx)
 


### PR DESCRIPTION
Previously we rejected metadata api on metadata that were not defined in the config. This commit relaxes this and allows add, update, remove ops on metadata names that don't exist in config (we still parse the name/tag and create diff hunks the same way).

Should be non-breaking as this is a gain-of-function and doesn't necessarily break the API contract