### PR TITLE
feat(api): add additional helpers to Todo class

### DIFF
--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -153,11 +153,15 @@ end
 ---@field indent number Number of spaces before the list marker
 ---@field list_marker string List item marker, e.g. `-`, `*`, `+`
 ---@field todo_marker string Todo marker, e.g. `□`, `✔`
----@field is_checked fun(): boolean Whether todo is checked
+---@field is_checked fun(): boolean Whether todo state is explicitly "checked". If custom states are used, you may want to use `is_complete()`.
+---@field is_unchecked fun(): boolean Whether todo state is explicitly "unchecked". If custom states are used, you may want to use `is_incomplete()`.
+---@field is_complete fun(): boolean Whether todo state type is "complete" (this includes "checked" state, by default)
+---@field is_incomplete fun(): boolean Whether todo state type is "incomplete" (this includes "unchecked" state, by default)
+---@field is_inactive fun(): boolean Whether todo state type is "inactive" (may be used by custom todo states)
 ---@field metadata string[][] Table of {tag, value} tuples
 ---@field get_metadata fun(name: string): string?, string? Returns 1. tag, 2. value, if exists
 ---@field get_parent fun(): checkmate.Todo|nil Returns the parent todo item, or nil
----@field _todo_item checkmate.TodoItem internal representation (use at your own risk)
+---@field _todo_item checkmate.TodoItem internal representation (use at your own risk, not guaranteed to be stable)
 
 ---@class checkmate.MetadataContext
 ---@field name string Metadata tag name

--- a/lua/checkmate/util.lua
+++ b/lua/checkmate/util.lua
@@ -712,6 +712,22 @@ function M.build_todo(todo_item)
     return todo_item.state == "checked"
   end
 
+  local function is_unchecked()
+    return todo_item.state == "unchecked"
+  end
+
+  local function is_complete()
+    return todo_item.state_type == "complete"
+  end
+
+  local function is_incomplete()
+    return todo_item.state_type == "incomplete"
+  end
+
+  local function is_inactive()
+    return todo_item.state_type == "inactive"
+  end
+
   local function get_metadata(name)
     local result = vim
       .iter(metadata_array)
@@ -743,6 +759,10 @@ function M.build_todo(todo_item)
     todo_marker = todo_item.todo_marker.text,
     metadata = metadata_array,
     is_checked = is_checked,
+    is_unchecked = is_unchecked,
+    is_complete = is_complete,
+    is_incomplete = is_incomplete,
+    is_inactive = is_inactive,
     get_metadata = get_metadata,
     get_parent = get_parent,
     _todo_item = todo_item,

--- a/tests/checkmate/metadata_spec.lua
+++ b/tests/checkmate/metadata_spec.lua
@@ -54,8 +54,24 @@ describe("Metadata", function()
       assert.are_same(todo.metadata, { { "priority", "high" }, { "started", "today" } })
 
       assert.is_function(todo.is_checked)
-      local c = todo.is_checked()
+      local ch = todo.is_checked()
+      assert.is_false(ch)
+
+      assert.is_function(todo.is_unchecked)
+      local uch = todo.is_unchecked()
+      assert.is_true(uch)
+
+      assert.is_function(todo.is_complete)
+      local c = todo.is_complete()
       assert.is_false(c)
+
+      assert.is_function(todo.is_incomplete)
+      local ic = todo.is_incomplete()
+      assert.is_true(ic)
+
+      assert.is_function(todo.is_inactive)
+      local ia = todo.is_inactive()
+      assert.is_false(ia)
 
       assert.is_function(todo.get_metadata)
 


### PR DESCRIPTION
in addition to existing `is_checked()`, adds `is_unchecked()`, and the perhaps semantically more intuitive `is_complete()`, `is_incomplete()`, and `is_inactive()`, based on the todo's state _type_. This is most relevant when user's have configured custom todo states.