### PR TITLE
fix: overwriting symlinks

### DIFF
--- a/lua/checkmate/buffer/init.lua
+++ b/lua/checkmate/buffer/init.lua
@@ -533,6 +533,17 @@ function Buffer:_setup_autocmds()
         local current_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
         local filename = vim.api.nvim_buf_get_name(bufnr)
 
+        -- Ensure we don't accidentally convert symlinks to real files
+        local link_target = uv.fs_readlink(filename)
+        if link_target then
+          -- handle relative symlink targets
+          if not link_target:match("^/") then
+            local dirname = vim.fn.fnamemodify(filename, ":h")
+            link_target = dirname .. "/" .. link_target
+          end
+          filename = vim.fn.resolve(link_target)
+        end
+
         -- create temp buffer and convert to markdown
         local temp_bufnr = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_lines(temp_bufnr, 0, -1, false, current_lines)

--- a/lua/checkmate/buffer/init.lua
+++ b/lua/checkmate/buffer/init.lua
@@ -533,15 +533,18 @@ function Buffer:_setup_autocmds()
         local current_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
         local filename = vim.api.nvim_buf_get_name(bufnr)
 
-        -- Ensure we don't accidentally convert symlinks to real files
+        -- Handle symlinks correctly (see #226)
+        --  - Ensure we write the resolved file, not the symlink path
+        --  - Ensure we don't accidentally convert symlinks to real files
         local link_target = uv.fs_readlink(filename)
         if link_target then
-          -- handle relative symlink targets
-          if not link_target:match("^/") then
-            local dirname = vim.fn.fnamemodify(filename, ":h")
-            link_target = dirname .. "/" .. link_target
+          local realpath, err = uv.fs_realpath(filename)
+          if not realpath then
+            vim.notify("Checkmate: Failed to resolve symlink: " .. (err or "unknown error"), vim.log.levels.ERROR)
+            self._local:set("writing", false)
+            return false
           end
-          filename = vim.fn.resolve(link_target)
+          filename = realpath
         end
 
         -- create temp buffer and convert to markdown

--- a/tests/checkmate/api_spec.lua
+++ b/tests/checkmate/api_spec.lua
@@ -304,6 +304,56 @@ describe("API", function()
           vim.api.nvim_clear_autocmds({ group = augroup })
         end)
       end)
+
+      it("should handle symlinks correctly", function()
+        local uv = vim.uv
+        -- make a real file
+        local bufnr, real_file = h.setup_todo_file_buffer("- [ ] Real file todo")
+        local real_file_exists = vim.uv.fs_stat(real_file)
+        assert.is_not_nil(real_file_exists)
+
+        -- use .todo.md suffix to ensure it matches default Checkmate file name trigger
+        local link_path = vim.fn.tempname() .. "_link.todo.md"
+
+        -- make symlink... link_path is just a path that points to the real_file
+        local ok, err = uv.fs_symlink(real_file, link_path)
+        if err then
+          print(err)
+        end
+        assert.is_true(ok)
+
+        -- now we close the buffer opened on the real path...reopen using the symlink path
+        -- i.e., user opens a symlinked file
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+        local link_bufnr = vim.fn.bufadd(link_path)
+        vim.fn.bufload(link_bufnr)
+
+        vim.api.nvim_buf_call(link_bufnr, function()
+          ---@diagnostic disable-next-line: unused-local, missing-fields
+
+          vim.api.nvim_buf_set_lines(link_bufnr, 0, -1, false, { "- [ ] Updated via symlink", "" })
+          assert.is_true(vim.bo[link_bufnr].modified)
+
+          -- this is the crux. It should write the original file, not just use the symlink path as the file
+          vim.cmd("silent write")
+          vim.wait(20)
+
+          assert.is_false(vim.bo[link_bufnr].modified)
+        end)
+
+        -- make sure the real file has the updated content
+        local real_content = h.read_file_content(real_file)
+        real_content = h.exists(real_content, "Real file content should be readable")
+        assert.matches("Updated via symlink", real_content)
+
+        -- symlink should still be a symlink (not replaced by a regular file)
+        h.exists(uv.fs_readlink(link_path), "link_path should still be a symlink after write")
+
+        finally(function()
+          pcall(uv.fs_unlink, link_path)
+          h.cleanup_file(real_file)
+        end)
+      end)
     end)
   end)
 


### PR DESCRIPTION
Previous behavior: `:wq` on a symlink that is linked to a file that checkmate works with will overwrite the symlink with the content of the changed file *without* updating the original either. Confirmed by enabling/disabling checkmate alone and verifying that modifying and saving the file does/doesn't affect the symlink.

`fs_rename` will always directly overwrite the target file with the temp file even if it is a symbolic link, which breaks the link along with any user assumptions about it. This fix tries to address it by first checking if there is a link, and then following the link (after potentially adjusting for the right path if relative), then use that as the real filename.

Tests: my own symlinked file now no longer gets converted to a real file. Granted, not an extensive test.