### PR TITLE
Update internal lazy loading, add vim.pack documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-file test-interactive clean
+.PHONY: test test-file test-interactive test-interactive-pack clean
 
 # allow `make test DEBUG=1` (or any other target) to export DEBUG=1
 DEBUG ?= 0
@@ -74,9 +74,26 @@ test-file:
 
 # -------------------------------------------------
 #   make test-interactive
+#
+#   Uses lazy.nvim
 # -------------------------------------------------
 test-interactive:
 	@nvim -u tests/interactive.lua 
+
+# -------------------------------------------------
+#   make test-interactive-pack
+#
+#   Uses vim.pack
+# -------------------------------------------------
+
+test-interactive-pack:
+	@TEST_ENV=$(or $(TEST_ENV),default) \
+	NVIM_APPNAME=$(or $(TEST_ENV),default) \
+	XDG_DATA_HOME=$(CURDIR)/.testdata/interactive-pack/data \
+	XDG_CONFIG_HOME=$(CURDIR)/.testdata/interactive-pack/config \
+	XDG_STATE_HOME=$(CURDIR)/.testdata/interactive-pack/state \
+	XDG_CACHE_HOME=$(CURDIR)/.testdata/interactive-pack/cache \
+	nvim -u tests/interactive_pack.lua
 
 # -------------------------------------------------
 # Clean up any test artifacts

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ https://github.com/user-attachments/assets/d5fa2fc8-085a-4cee-9763-a392d543347e
 ```lua
 {
   "bngarren/checkmate.nvim",
-  ft = "markdown", -- Lazy loads for Markdown files matching patterns in 'files'
   opts = {
     -- files = { "*.md" }, -- any .md file (instead of defaults)
   },
@@ -90,11 +89,28 @@ https://github.com/user-attachments/assets/d5fa2fc8-085a-4cee-9763-a392d543347e
 
 If you'd like _stable-ish_ version during pre-release, can add a minor version to the [lazy spec](https://lazy.folke.io/spec#spec-versioning):
 
-```
+```lua
 {
   version = "~0.12.0" -- pins to minor 0.12.x
 }
 ```
+
+### Using vim.pack
+
+```lua
+vim.pack.add({
+  {
+    src = "https://github.com/bngarren/checkmate.nvim",
+  },
+})
+
+require("checkmate").setup({
+  -- files = { "*.md" },
+})
+```
+
+#### Lazy loading
+Checkmate manages its own "lazy loading". Calling `setup()` is lightweight: it validates the config and registers an activation autocmd. The runtime is only started when a buffer has `filetype=markdown` and its filename matches `opts.files`.
 
 <a id="usage"><a/>
 

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -1699,17 +1699,17 @@ function H.set_config_enabled(enabled)
   end
 end
 
----This installs the lightweight activation autocmds and starts the runtime if a
----matching buffer already exists. It is intentionally safe to call multiple
----times.
+---Installs the lightweight activation autocmds and starts the runtime if a
+---matching buffer already exists. safe to call multiple
+---times
 function H.enable_activation()
   H.setup_activation_autocommands()
   H.maybe_start_for_existing_buffers()
 end
 
----Removes only the lightweight activation autocmds. It does not stop the
----runtime or deactivate active buffers; callers that want full shutdown should
----also call `H.stop()`.
+---Removes only the activation autocmds. it does not stop the
+---runtime or deactivate active buffers... for full shutdown should
+---also call `H.stop()`
 function H.disable_activation()
   pcall(vim.api.nvim_del_augroup_by_name, H.augroups.activation)
 end
@@ -2016,7 +2016,7 @@ function H.notify_no_todos_found(is_visual)
   require("checkmate.util").notify(string.format("No todo items found %s", mode_msg), vim.log.levels.INFO)
 end
 
---exposed internals
+--exposed internals for dev/testing
 M._start = H.start
 M._stop = H.stop
 M._activate = H.activate

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -76,20 +76,26 @@ M.PICKERS = {
 ---@field metadata? table<string, string|boolean> Filter by metadata key-value pairs. For tags, use true (tag exists) or false (tag absent). For metadata with values, use the string value (e.g., {urgent = true, priority = "high"}). Default: match ANY.
 ---@field metadata_match_all? boolean If true, require ALL metadata pairs to match (default: false - match ANY)
 
--- Globally disables/deactivates Checkmate for all buffers
+-- Globally disables/deactivates Checkmate for all buffers.
 ---@return nil
 function M.disable()
-  local cfg = require("checkmate.config")
-  cfg.options.enabled = false
-  M._stop()
+  H.set_config_enabled(false)
+  H.disable_activation()
+  H.stop()
 end
 
--- Starts/activates Checkmate
+-- Globally enables Checkmate.
 ---@return nil
 function M.enable()
-  local cfg = require("checkmate.config")
-  cfg.options.enabled = true
-  M.setup(H.state.user_opts)
+  if not H.is_initialized() then
+    local opts = vim.deepcopy(H.state.user_opts or {})
+    opts.enabled = true
+    M.setup(opts)
+    return
+  end
+
+  H.set_config_enabled(true)
+  H.enable_activation()
 end
 
 --- Toggle todo item(s) state under cursor or per todo in visual selection
@@ -1577,17 +1583,17 @@ end
 M.setup = function(opts)
   local config = require("checkmate.config")
 
-  H.state.user_opts = opts or {}
-
   -- reload if config has changed
   if H.is_initialized() then
-    local current_config = config.options
-    if opts and not vim.deep_equal(opts, current_config) then
+    if opts and not vim.deep_equal(opts, H.state.user_opts) then
       H.stop()
+      H.reset_all()
     else
       return true
     end
   end
+
+  H.state.user_opts = vim.deepcopy(opts or {})
 
   local success, err = pcall(function()
     if H.is_running() then
@@ -1606,6 +1612,12 @@ M.setup = function(opts)
     end
 
     H.set_initialized(true)
+
+    if cfg.enabled then
+      H.enable_activation()
+    else
+      H.disable_activation()
+    end
   end)
 
   if not success then
@@ -1614,18 +1626,14 @@ M.setup = function(opts)
       msg = msg .. "\n" .. tostring(err)
     end
     vim.notify(msg, vim.log.levels.ERROR)
-    H.reset()
+    H.reset_all()
     return false
   end
 
   -- got here but not initialized, ?config error, do graceful cleanup
   if not H.is_initialized() then
-    H.reset()
+    H.reset_all()
     return false
-  end
-
-  if config.options.enabled then
-    H.start()
   end
 
   return true
@@ -1636,16 +1644,219 @@ end
 -- These are not part of the public API and thus do not have semver stability.
 -- ================================================================================
 
+--[[
+Checkmate lifecycle
+
+`setup(opts)` validates and stores configuration, then installs lightweight
+activation autocmd. It does not eagerly start the full runtime unless a
+matching buffer already exists.
+
+Activation is split into two layers:
+
+1. Global runtime
+   `start()` initializes shared services: logging, parser state, highlights,
+   linter state, and runtime autocmds.
+
+2. Buffer runtime
+   `activate(bufnr)` attaches Checkmate to a single buffer only when all
+   activation criteria are met:
+     - config is enabled
+     - buffer is valid and loaded
+     - filetype is "markdown"
+     - filename matches `config.files`
+
+`stop()` shuts down runtime resources and active buffers, but preserves the
+validated configuration. Full reset is reserved for setup failure,
+reconfiguration, or tests.
+]]
+
 H.state = {
-  -- initialized is config setup
+  -- config has been validated and applied
   initialized = false,
-  -- core modules are setup (parser, highlights, linter) and autocmds registered
+
+  -- global runtime is active:
+  -- logger/parser/highlights/linter are setup and runtime autocmds are registered
   running = false,
-  -- save initial user opts for later restarts
+
+  -- original user opts, preserved for restarts / reloads
   user_opts = {},
 }
 
--- spin up logger, parser, highlights, linter, autocmds
+H.augroups = {
+  activation = "checkmate_activation",
+  global = "checkmate_global",
+  highlights = "checkmate_highlights",
+  buffer = "checkmate_buffer",
+}
+
+--- Modifies the current config
+---@param enabled boolean
+function H.set_config_enabled(enabled)
+  local cfg = require("checkmate.config")
+
+  if cfg.options then
+    cfg.options.enabled = enabled
+  end
+end
+
+---This installs the lightweight activation autocmds and starts the runtime if a
+---matching buffer already exists. It is intentionally safe to call multiple
+---times.
+function H.enable_activation()
+  H.setup_activation_autocommands()
+  H.maybe_start_for_existing_buffers()
+end
+
+---Removes only the lightweight activation autocmds. It does not stop the
+---runtime or deactivate active buffers; callers that want full shutdown should
+---also call `H.stop()`.
+function H.disable_activation()
+  pcall(vim.api.nvim_del_augroup_by_name, H.augroups.activation)
+end
+
+---@param bufnr integer
+---@return boolean
+function H.should_activate_buffer(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) or not vim.api.nvim_buf_is_loaded(bufnr) then
+    return false
+  end
+
+  local cfg = require("checkmate.config").options
+  if not (cfg and cfg.enabled) then
+    return false
+  end
+
+  if vim.bo[bufnr].filetype ~= "markdown" then
+    return false
+  end
+
+  return require("checkmate.file_matcher").should_activate_for_buffer(bufnr, cfg.files)
+end
+
+--- Attach checkmate to one buffer if it satisfies activation criteria
+--- yay hopefully idempotent... does nothing if the buffer is already active
+---@param bufnr integer
+function H.activate(bufnr)
+  if not H.should_activate_buffer(bufnr) then
+    return
+  end
+
+  local Buffer = require("checkmate.buffer")
+
+  if Buffer.is_active(bufnr) then
+    return
+  end
+
+  require("checkmate.commands").setup(bufnr)
+
+  local buf = Buffer.get(bufnr)
+  buf:setup()
+end
+
+---@param bufnr integer
+function H.deactivate(bufnr)
+  local Buffer = require("checkmate.buffer")
+
+  if not Buffer.is_active(bufnr) then
+    return
+  end
+
+  require("checkmate.commands").dispose(bufnr)
+
+  local buf = Buffer.get(bufnr)
+  buf:shutdown()
+end
+
+--- start the runtime if any currently loaded buffer should be managed by checkmate
+--- otherwise, the activation autocmd will start new buffers later
+function H.maybe_start_for_existing_buffers()
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if H.should_activate_buffer(bufnr) then
+      H.start()
+      return
+    end
+  end
+end
+
+-- if Checkmate starts after a markdown buffer already exists, it still activates that buffer
+function H.setup_existing_markdown_buffers()
+  local log = require("checkmate.log")
+
+  local existing_buffers = {}
+
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if H.should_activate_buffer(bufnr) then
+      table.insert(existing_buffers, bufnr)
+      H.activate(bufnr)
+    end
+  end
+
+  local count = #existing_buffers
+  if count > 0 then
+    log.fmt_info(
+      "[main] %d existing Checkmate buffers found during startup: %s",
+      count,
+      table.concat(existing_buffers, ", ")
+    )
+  end
+end
+
+-- allows for lazy loading of checkmate's runtime
+function H.setup_activation_autocommands()
+  local augroup = vim.api.nvim_create_augroup(H.augroups.activation, { clear = true })
+
+  vim.api.nvim_create_autocmd("FileType", {
+    group = augroup,
+    pattern = "markdown",
+    callback = function(event)
+      if not H.should_activate_buffer(event.buf) then
+        return
+      end
+
+      H.start()
+      H.activate(event.buf)
+    end,
+  })
+end
+
+function H.setup_runtime_autocommands()
+  local log = require("checkmate.log")
+
+  local augroup = vim.api.nvim_create_augroup(H.augroups.global, { clear = true })
+
+  vim.api.nvim_create_autocmd("VimLeavePre", {
+    group = augroup,
+    callback = function()
+      H.stop()
+    end,
+  })
+
+  vim.api.nvim_create_autocmd("FileType", {
+    group = augroup,
+    pattern = "markdown",
+    callback = function(event)
+      log.fmt_debug("[autocmd] Filetype = '%s' Bufnr = %d'", event.match, event.buf)
+      H.activate(event.buf)
+    end,
+  })
+
+  vim.api.nvim_create_autocmd("FileType", {
+    group = augroup,
+    callback = function(event)
+      if event.match == "markdown" then
+        return
+      end
+
+      local Buffer = require("checkmate.buffer")
+      if Buffer.is_active(event.buf) then
+        log.fmt_info("[autocmd] Filetype = '%s', turning off Checkmate for bufnr %d", event.match, event.buf)
+        H.deactivate(event.buf)
+      end
+    end,
+  })
+end
+
+-- boots the checkmate runtime
 function H.start()
   if H.is_running() then
     return
@@ -1667,120 +1878,64 @@ function H.start()
 
     H.set_running(true)
 
-    H.setup_autocommands()
-
+    H.setup_runtime_autocommands()
     H.setup_existing_markdown_buffers()
 
     log.info("[main] ✔ Checkmate started successfully")
   end)
+
   if not success then
     vim.notify("Checkmate: Failed to start: " .. tostring(err), vim.log.levels.ERROR)
-    H.stop() -- cleanup partial initialization
+    H.cleanup_runtime()
   end
 end
 
-function H.stop()
-  if not H.is_running() then
-    return
+---@param opts? { log_stop?: boolean }
+function H.cleanup_runtime(opts)
+  opts = opts or {}
+
+  local active_count = 0
+
+  if package.loaded["checkmate.buffer"] then
+    pcall(function()
+      local Buffer = require("checkmate.buffer")
+      active_count = Buffer.count_active()
+      Buffer.shutdown_all()
+    end)
   end
-
-  local Buffer = require("checkmate.buffer")
-
-  local active_count = Buffer.count_active()
-
-  Buffer.shutdown_all()
 
   pcall(vim.api.nvim_del_augroup_by_name, "checkmate_global")
   pcall(vim.api.nvim_del_augroup_by_name, "checkmate_highlights")
   pcall(vim.api.nvim_del_augroup_by_name, "checkmate_buffer")
 
-  local parser = require("checkmate.parser")
-  parser.clear_parser_cache()
+  if package.loaded["checkmate.parser"] then
+    pcall(function()
+      require("checkmate.parser").clear_parser_cache()
+    end)
+  end
 
   if package.loaded["checkmate.log"] then
     pcall(function()
       local log = require("checkmate.log")
-      log.fmt_info("[main] Checkmate stopped, with %d active buffers", active_count)
+
+      if opts.log_stop then
+        log.fmt_info("[main] Checkmate stopped, with %d active buffers", active_count)
+      end
+
       log.shutdown()
     end)
   end
 
-  H.reset()
+  H.reset_runtime()
 end
 
-function H.setup_autocommands()
-  local log = require("checkmate.log")
-  local Buffer = require("checkmate.buffer")
-
-  local augroup = vim.api.nvim_create_augroup("checkmate_global", { clear = true })
-
-  vim.api.nvim_create_autocmd("VimLeavePre", {
-    group = augroup,
-    callback = function()
-      H.stop()
-    end,
-  })
-
-  vim.api.nvim_create_autocmd("FileType", {
-    group = augroup,
-    pattern = "markdown",
-    callback = function(event)
-      log.fmt_debug("[autocmd] Filetype = '%s' Bufnr = %d'", event.match, event.buf)
-      local cfg = require("checkmate.config").options
-      if not (cfg and cfg.enabled) then
-        return
-      end
-
-      if require("checkmate.file_matcher").should_activate_for_buffer(event.buf, cfg.files) then
-        require("checkmate.commands").setup(event.buf)
-        local buf = Buffer.get(event.buf)
-        buf:setup()
-      end
-    end,
-  })
-
-  vim.api.nvim_create_autocmd("FileType", {
-    group = augroup,
-    callback = function(event)
-      if event.match ~= "markdown" then
-        if Buffer.is_active(event.buf) then
-          log.fmt_info("[autocmd] Filetype = '%s', turning off Checkmate for bufnr %d", event.match, event.buf)
-
-          require("checkmate.commands").dispose(event.buf)
-          local buf = Buffer.get(event.buf)
-          buf:shutdown()
-        end
-      end
-    end,
-  })
-end
-
-function H.setup_existing_markdown_buffers()
-  local config = require("checkmate.config")
-  local log = require("checkmate.log")
-  local file_matcher = require("checkmate.file_matcher")
-  local Buffer = require("checkmate.buffer")
-
-  local buffers = vim.api.nvim_list_bufs()
-
-  local existing_buffers = {}
-  for _, bufnr in ipairs(buffers) do
-    if
-      vim.api.nvim_buf_is_valid(bufnr)
-      and vim.api.nvim_buf_is_loaded(bufnr)
-      and vim.bo[bufnr].filetype == "markdown"
-      and file_matcher.should_activate_for_buffer(bufnr, config.options.files)
-    then
-      table.insert(existing_buffers, bufnr)
-      local buf = Buffer.get(bufnr)
-      buf:setup()
-    end
+-- shutsdown the runtime buts keep plugin configured
+function H.stop()
+  if not H.is_running() then
+    return
   end
 
-  local count = #existing_buffers
-  if count > 0 then
-    log.fmt_info("[main] %d existing Checkmate buffers found during startup: %s", count, existing_buffers)
-  end
+  H.cleanup_runtime({ log_stop = true })
 end
 
 function H.get_user_opts()
@@ -1803,9 +1958,19 @@ function H.set_running(value)
   H.state.running = value
 end
 
-function H.reset()
+-- stop runtime only
+-- stop() may shut down active Checkmate buffers and runtime resources, but the plugin
+-- should still remember that it was configured
+function H.reset_runtime()
+  H.state.running = false
+end
+
+-- forget config/setup entirely
+function H.reset_all()
   H.state.initialized = false
   H.state.running = false
+  ---@diagnostic disable-next-line: missing-fields
+  H.state.user_opts = {}
 end
 
 --- Checks that is metadata tag name (internally using it's canonical name)
@@ -1854,8 +2019,11 @@ end
 --exposed internals
 M._start = H.start
 M._stop = H.stop
+M._activate = H.activate
+M._deactivate = H.deactivate
 M._get_user_opts = H.get_user_opts
 M._is_initialized = H.is_initialized
 M._is_running = H.is_running
+M._reset = H.reset_all
 
 return M

--- a/tests/busted.lua
+++ b/tests/busted.lua
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S nvim -l
 
-vim.env.LAZY_STDPATH = ".testdata"
-vim.env.NVIM_APPNAME = "headless"
+vim.env.LAZY_STDPATH = ".testdata/busted"
+-- vim.env.NVIM_APPNAME = "headless"
 
 assert(loadfile("tests/lazy_bootstrap.lua"))()
 

--- a/tests/checkmate/helpers.lua
+++ b/tests/checkmate/helpers.lua
@@ -55,14 +55,43 @@ end
 -- Setup and Teardown
 -- =============================================================================
 
----Calls `require("checkmate").setup()` and merges with helpers.DEFAULT_TEST_CONFIG`
+---@param bufnr integer
+---@param timeout_ms? integer
+function M.wait_for_checkmate_running(bufnr, timeout_ms)
+  timeout_ms = timeout_ms or 100
+
+  local ok = vim.wait(timeout_ms, function()
+    local cm = require("checkmate")
+
+    if not cm._is_initialized() or not cm._is_running() then
+      return false
+    end
+
+    if bufnr then
+      local Buffer = require("checkmate.buffer")
+      return Buffer.is_active(bufnr)
+    end
+
+    return true
+  end, 5)
+
+  assert(ok, "Timeout waiting for Checkmate runtime")
+end
+
+---Calls `require("checkmate").setup()` and merges with helpers.DEFAULT_TEST_CONFIG.
+---This only initializes Checkmate config and activation autocmds. The runtime
+---starts later when a matching markdown buffer is activated.
 ---@param _config? checkmate.Config
 ---@param cm? Checkmate
+---@return Checkmate
 function M.cm_setup(_config, cm)
-  if not cm then
-    cm = require("checkmate")
-  end
-  cm.setup(vim.tbl_deep_extend("force", M.DEFAULT_TEST_CONFIG, _config or {}))
+  cm = cm or require("checkmate")
+
+  local config = vim.tbl_deep_extend("force", M.DEFAULT_TEST_CONFIG, _config or {})
+  local ok = cm.setup(config)
+
+  assert(ok, "Failed to setup Checkmate")
+
   return cm
 end
 
@@ -73,13 +102,15 @@ end
 function M.cleanup_test(bufnr)
   M.ensure_normal_mode()
 
-  pcall(require("checkmate")._stop)
-
-  if not bufnr then
-    return
+  local ok, cm = pcall(require, "checkmate")
+  if ok then
+    pcall(cm._stop)
+    pcall(cm._reset)
   end
 
-  pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+  end
 end
 
 function M.cleanup_file(file_path)
@@ -142,16 +173,31 @@ function M.wait_for_write(bufnr, timeout_ms)
   assert(ok, "Timeout waiting for buffer write")
 end
 
---- Creates a temp file and sets up a Checkmate buffer for this file
---- @param content string|string[]
---- @param opts? {file_path?: string, config?: table, wait_ms?: integer, skip_setup?: boolean}
---- @return integer bufnr
---- @return string file_path
+---@param bufnr integer
+---@param wait_ms? integer
+function M.activate_checkmate_buffer(bufnr, wait_ms)
+  wait_ms = wait_ms or 5
+
+  vim.api.nvim_set_current_buf(bufnr)
+  vim.bo[bufnr].filetype = "markdown"
+
+  vim.api.nvim_exec_autocmds("FileType", {
+    buffer = bufnr,
+    modeline = false,
+  })
+
+  -- vim.wait(wait_ms)
+end
+
+--- Creates a temp file and sets up a Checkmate buffer for this file.
+---@param content string|string[]
+---@param opts? {file_path?: string, config?: table, wait_ms?: integer, skip_setup?: boolean}
+---@return integer bufnr
+---@return string file_path
 function M.setup_todo_file_buffer(content, opts)
   opts = opts or {}
 
   local content_str = type(content) == "table" and table.concat(content, "\n") or content
-
   local file_path = opts.file_path or M.create_temp_file()
 
   if not M.write_file_content(file_path, content_str) then
@@ -159,55 +205,60 @@ function M.setup_todo_file_buffer(content, opts)
   end
 
   if not opts.skip_setup then
-    local _config = vim.tbl_deep_extend("force", M.DEFAULT_TEST_CONFIG, opts.config or {})
-    local ok = require("checkmate").setup(_config)
-    if not ok then
-      error("Failed to setup Checkmate in setup_todo_buffer")
-    end
+    M.cm_setup(opts.config)
   end
 
-  local bufnr = vim.api.nvim_create_buf(false, false)
-  vim.api.nvim_buf_set_name(bufnr, file_path)
-  vim.api.nvim_win_set_buf(0, bufnr)
-  vim.cmd("edit!")
+  vim.cmd("edit " .. vim.fn.fnameescape(file_path))
 
-  vim.bo[bufnr].filetype = "markdown"
+  local bufnr = vim.api.nvim_get_current_buf()
 
-  local wait_ms = opts.wait_ms or 5
-  vim.wait(wait_ms)
+  M.activate_checkmate_buffer(bufnr, opts.wait_ms or 100)
+
   vim.cmd("redraw")
 
   return bufnr, file_path
 end
 
--- Helper function to create a test buffer with todo content
---- @param content string|string[]
---- @param name string?
---- @return integer bufnr
+-- Helper function to create a plain test buffer with todo content.
+-- This does not call Checkmate setup or wait for Checkmate activation.
+---@param content string|string[]
+---@param name string?
+---@return integer bufnr
 function M.setup_test_buffer(content, name)
   local filename = name or "todo.md"
 
   local bufnr = vim.api.nvim_create_buf(true, false)
-
   vim.api.nvim_buf_set_name(bufnr, filename)
 
-  local lines
-  if type(content) == "table" then
-    lines = content
-  else
-    lines = vim.split(content, "\n")
-  end
-
+  local lines = type(content) == "table" and content or vim.split(content --[[@as string]], "\n")
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
   vim.api.nvim_win_set_buf(0, bufnr)
-
-  vim.bo[bufnr].filetype = "markdown"
-  vim.bo[bufnr].modifiable = true
-
   vim.api.nvim_set_current_buf(bufnr)
 
+  vim.bo[bufnr].modifiable = true
+  vim.bo[bufnr].filetype = "markdown"
+
   return bufnr
+end
+
+--- Creates an in-memory markdown buffer, initializes Checkmate, and activates it.
+---@param content string|string[]
+---@param opts? {name?: string, config?: table, wait_ms?: integer, skip_setup?: boolean}
+---@return integer bufnr, Checkmate cm
+function M.setup_checkmate_test_buffer(content, opts)
+  opts = opts or {}
+  local cm
+
+  if opts.skip_setup ~= true then
+    cm = M.cm_setup(opts.config)
+  end
+
+  local bufnr = M.setup_test_buffer(content, opts.name)
+
+  M.activate_checkmate_buffer(bufnr, opts.wait_ms or 100)
+
+  return bufnr, cm
 end
 
 -- Assertion and Validation Helpers

--- a/tests/checkmate/lifecycle_spec.lua
+++ b/tests/checkmate/lifecycle_spec.lua
@@ -1,3 +1,4 @@
+---@module "tests.checkmate.helpers"
 local h
 
 describe("checkmate init and lifecycle", function()
@@ -23,16 +24,21 @@ describe("checkmate init and lifecycle", function()
       local checkmate = require("checkmate")
       local config = require("checkmate.config")
       local result = checkmate.setup()
+
       assert.is_true(result)
-      assert.is_true(checkmate._is_running())
+      assert.is_true(checkmate._is_initialized())
+      assert.is_false(checkmate._is_running()) -- runtime should not be starting automatically after setup()
+
       local actual = vim.deepcopy(config.options)
       actual.style = {} -- to match expected because default has style = {}
       actual.todo_states.checked.markdown = nil -- won't be in expected/default as it is added during setup
       actual.todo_states.checked.type = nil
       actual.todo_states.unchecked.markdown = nil
       actual.todo_states.unchecked.type = nil
+
       local expected = config.get_defaults()
       assert.same(expected, actual)
+
       checkmate._stop()
     end)
 
@@ -56,6 +62,7 @@ describe("checkmate init and lifecycle", function()
 
       local result = checkmate.setup(custom_config)
       assert.is_true(result)
+
       assert.equal(2, #config.options.files)
       assert.equal("tasks.md", config.options.files[1])
       assert.equal("*.task", config.options.files[2])
@@ -83,68 +90,95 @@ describe("checkmate init and lifecycle", function()
       checkmate._stop()
     end)
 
-    it("should stop existing instance before starting new one", function()
-      local checkmate = require("checkmate")
+    it("should stop existing runtime before applying new config", function()
       local config = require("checkmate.config")
 
-      checkmate.setup()
-      assert.is_true(checkmate._is_running())
+      local bufnr, cm = h.setup_checkmate_test_buffer("", {
+        skip_setup = false,
+      })
 
-      -- Second setup should stop first instance
-      ---@diagnostic disable-next-line: missing-fields, assign-type-mismatch
-      local result = checkmate.setup({ notify = false })
+      assert.is_true(cm._is_running())
+      assert.is_true(require("checkmate.buffer").is_active(bufnr))
+
+      ---@diagnostic disable-next-line: missing-fields
+      local result = cm.setup({ notify = false })
+
       assert.is_true(result)
-      assert.is_true(checkmate._is_running())
+      assert.is_true(cm._is_initialized())
+
+      -- after reconfiguration, runtime should start again because the matching
+      -- markdown buffer still exists.
+      config = require("checkmate.config")
+      assert.is_true(cm._is_running())
       assert.is_false(config.options.notify)
 
-      checkmate._stop()
+      h.cleanup_test(bufnr)
     end)
 
     it("should not start when enabled is false", function()
       local checkmate = require("checkmate")
       ---@diagnostic disable-next-line: missing-fields, assign-type-mismatch
       local result = checkmate.setup({ enabled = false })
+      local bufnr = h.setup_checkmate_test_buffer("", { skip_setup = true })
+      -- should attempt to activate buffer but fail
+
       assert.is_true(result)
       assert.is_false(checkmate._is_running())
 
-      checkmate._stop()
+      h.cleanup_test(bufnr)
     end)
 
     it("should activate existing markdown buffers on setup", function()
       local checkmate = require("checkmate")
 
-      vim.cmd("edit todo")
+      vim.cmd("edit todo.md")
       local bufnr = vim.api.nvim_get_current_buf()
-      vim.bo[bufnr].filetype = "markdown"
 
       -- setup should activate this buffer
+      -- via `maybe_start_for_existing_buffers`
       checkmate.setup()
 
-      vim.wait(20)
+      vim.wait(10)
 
       local buffer = require("checkmate.buffer").get(bufnr)
 
       assert.is_true(buffer._local:get("setup_complete"))
 
-      checkmate._stop()
+      h.cleanup_test(bufnr)
     end)
   end)
 
   describe("plugin state", function()
     it("should track running state correctly", function()
       local checkmate = require("checkmate")
+
       checkmate.setup()
+
+      assert.is_true(checkmate._is_initialized())
+      assert.is_false(checkmate._is_running())
+
+      local bufnr = h.setup_checkmate_test_buffer("", {})
 
       assert.is_true(checkmate._is_running())
 
       checkmate._stop()
       assert.is_false(checkmate._is_running())
+
+      -- _stop() should preserve initialized state
+      assert.is_true(checkmate._is_initialized())
+
+      h.cleanup_test(bufnr)
     end)
 
     it("should handle multiple start calls", function()
       local checkmate = require("checkmate")
+
       checkmate.setup()
 
+      assert.is_true(checkmate._is_initialized())
+      assert.is_false(checkmate._is_running())
+
+      checkmate._start()
       assert.is_true(checkmate._is_running())
 
       checkmate._start()
@@ -159,9 +193,11 @@ describe("checkmate init and lifecycle", function()
 
       checkmate._stop()
       assert.is_false(checkmate._is_running())
+      assert.is_true(checkmate._is_initialized())
 
       checkmate._stop()
       assert.is_false(checkmate._is_running())
+      assert.is_true(checkmate._is_initialized())
     end)
 
     it("should clean up resources on stop", function()
@@ -193,7 +229,7 @@ describe("checkmate init and lifecycle", function()
 
       assert.equal(0, Buffer.count_active())
 
-      vim.api.nvim_buf_delete(bufnr, { force = true })
+      h.cleanup_test(bufnr)
     end)
 
     it("should handle a disable then enable cycle", function()
@@ -203,7 +239,7 @@ describe("checkmate init and lifecycle", function()
       checkmate.setup()
 
       assert.is_true(checkmate._is_initialized())
-      assert.is_true(checkmate._is_running())
+      assert.is_false(checkmate._is_running())
       assert.equal(0, Buffer.count_active())
 
       local content = [[
@@ -215,8 +251,12 @@ describe("checkmate init and lifecycle", function()
   Regular line
       ]]
 
-      local bufnr = h.setup_test_buffer(content, "todo")
+      local bufnr = h.setup_checkmate_test_buffer(content, {
+        skip_setup = true,
+        name = "todo",
+      })
 
+      assert.is_true(checkmate._is_running())
       assert.is_true(Buffer.is_active(bufnr))
       assert.equal(1, Buffer.count_active())
       assert.equal(bufnr, Buffer.get_active_buffers()[1])
@@ -246,6 +286,7 @@ describe("checkmate init and lifecycle", function()
 
       checkmate.enable()
 
+      assert.is_true(checkmate._is_running())
       assert.is_true(Buffer.is_active(bufnr))
       assert.equal(1, Buffer.count_active())
       assert.equal(bufnr, Buffer.get_active_buffers()[1])
@@ -253,6 +294,8 @@ describe("checkmate init and lifecycle", function()
       buf_string = table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
       ok = h.verify_content_lines(buf_string, expected_lines)
       assert.is_true(ok)
+
+      h.cleanup_test(bufnr)
     end)
   end)
 
@@ -271,7 +314,7 @@ describe("checkmate init and lifecycle", function()
 
       assert.is_true(buffer._local:get("setup_complete"))
 
-      checkmate._stop()
+      h.cleanup_test(bufnr)
     end)
 
     it("should not activate for non-matching files", function()
@@ -287,7 +330,7 @@ describe("checkmate init and lifecycle", function()
 
       assert.is_falsy(buffer._local:get("setup_complete"))
 
-      checkmate._stop()
+      h.cleanup_test(bufnr)
     end)
 
     it("should handle buffer deletion", function()
@@ -308,6 +351,8 @@ describe("checkmate init and lifecycle", function()
 
       active_buffers = Buffer.get_active_buffer_map()
       assert.is_nil(active_buffers[bufnr])
+
+      h.cleanup_test(bufnr)
     end)
   end)
 

--- a/tests/interactive.lua
+++ b/tests/interactive.lua
@@ -38,7 +38,7 @@ if not ok then
   env_name = "base"
 end
 
-vim.env.LAZY_STDPATH = ".testdata"
+vim.env.LAZY_STDPATH = ".testdata/lazy"
 vim.env.NVIM_APPNAME = env_name
 
 -- base specs for all environments

--- a/tests/interactive_pack.lua
+++ b/tests/interactive_pack.lua
@@ -1,0 +1,104 @@
+#!/usr/bin/env -S nvim -l
+
+-- Manual interactive testing using Neovim 0.12+ vim.pack
+--
+-- Expected launch:
+--   make test-interactive-pack TEST_ENV=demo
+--
+-- The Makefile should set XDG_* paths and NVIM_APPNAME from TEST_ENV before Nvim starts
+-- so each test environment has isolated config/data/state/cache.
+
+if vim.fn.has("nvim-0.12") == 0 then
+  error("interactive_pack.lua requires Neovim 0.12+ for vim.pack")
+end
+
+for _, m in ipairs({
+  "matchparen",
+  "matchit",
+  "logiPat",
+  "rrhelper",
+  "netrwPlugin",
+}) do
+  vim.g["loaded_" .. m] = 1
+end
+
+local env_name = vim.env.TEST_ENV or "default"
+local cwd = vim.fn.getcwd()
+
+package.path = cwd .. "/tests/?.lua;" .. cwd .. "/tests/?/init.lua;" .. package.path
+
+local function require_env(name)
+  local mod = "fixtures.environments.pack." .. name
+  local ok, env = pcall(require, mod)
+
+  if ok then
+    return env, name
+  end
+
+  if name == "default" then
+    error(("Failed to load default environment:\n%s"):format(env))
+  end
+
+  vim.print(("Failed to load environment '%s', loading 'default'"):format(name))
+  vim.print(env)
+
+  local ok_default, default_env = pcall(require, "fixtures.environments.pack.default")
+  if not ok_default then
+    error("Failed to load default environment:\n" .. tostring(default_env))
+  end
+
+  return default_env, "default"
+end
+
+local base = require("fixtures.environments.pack.base")
+local env
+env, env_name = require_env(env_name)
+
+-- get user config on the runtimepath so setup editor with defaults
+local my_config_path = vim.fs.abspath(vim.env.USER_NVIM_CONFIG or "~/.config/nvim")
+vim.opt.runtimepath:prepend(my_config_path)
+package.path = table.concat({
+  my_config_path .. "/lua/?.lua",
+  my_config_path .. "/lua/?/init.lua",
+  package.path,
+}, ";")
+dofile(vim.fs.abspath("~/.config/nvim/lua/bngarren/core/init.lua"))
+
+-- Shared test setup
+if type(base.setup) == "function" then
+  base.setup()
+end
+
+-- Environment-specific setup
+if type(env.setup) == "function" then
+  env.setup()
+end
+
+-- local root = vim.fs.root(0, ".git") or cwd
+-- vim.opt.runtimepath:prepend(root)
+--
+-- local checkmate_opts = vim.tbl_deep_extend("force", base.checkmate or {}, env.checkmate or {})
+--
+-- local ok_checkmate, checkmate = pcall(require, "checkmate")
+-- if not ok_checkmate then
+--   error("Failed to require local checkmate.nvim: " .. tostring(checkmate))
+-- end
+--
+-- checkmate.setup(checkmate_opts)
+
+-- Post-setup hooks
+if type(base.config) == "function" then
+  vim.schedule(base.config)
+end
+
+if type(env.config) == "function" then
+  vim.schedule(env.config)
+end
+
+if vim.env.FILE then
+  vim.cmd.edit(vim.fn.fnameescape(vim.env.FILE))
+elseif env_name == "demo" then
+  vim.cmd.edit("tests/fixtures/demo.todo.md")
+else
+  vim.cmd.edit("tests/fixtures/test.todo.md")
+end

--- a/tests/interactive_pack.lua
+++ b/tests/interactive_pack.lua
@@ -53,6 +53,7 @@ end
 local base = require("fixtures.environments.pack.base")
 local env
 env, env_name = require_env(env_name)
+vim.print("Loaded: " .. env_name)
 
 -- get user config on the runtimepath so setup editor with defaults
 local my_config_path = vim.fs.abspath(vim.env.USER_NVIM_CONFIG or "~/.config/nvim")
@@ -73,18 +74,6 @@ end
 if type(env.setup) == "function" then
   env.setup()
 end
-
--- local root = vim.fs.root(0, ".git") or cwd
--- vim.opt.runtimepath:prepend(root)
---
--- local checkmate_opts = vim.tbl_deep_extend("force", base.checkmate or {}, env.checkmate or {})
---
--- local ok_checkmate, checkmate = pcall(require, "checkmate")
--- if not ok_checkmate then
---   error("Failed to require local checkmate.nvim: " .. tostring(checkmate))
--- end
---
--- checkmate.setup(checkmate_opts)
 
 -- Post-setup hooks
 if type(base.config) == "function" then

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -29,6 +29,7 @@ _G.reset_state = function(close_buffers)
       local checkmate = require("checkmate")
       if checkmate._is_running() then
         checkmate._stop()
+        checkmate._reset()
       end
     end)
   end


### PR DESCRIPTION
This PR ensures that checkmate essentially handles its own lazy loading, making it easier for installation via vim.pack. The plugin entry, `setup()`, is a lightweight function that ingests the config and registers an autocmd that will only boot the rest of the runtime when a buffer is opened that matches the criteria (e.g., markdown buffer with filename matching config.files)