### PR TITLE
Refine picker completion contracts

### DIFF
--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -1458,7 +1458,6 @@ end
 ---@field range? integer[] Start and end row (0-based, inclusive). Use {0, -1} or omit for entire buffer
 ---@field filter? checkmate.FilterOpts
 ---@field picker_opts? checkmate.PickerOpts
---- Feature-level custom picker. Existing custom_picker(todos) callbacks remain valid.
 --- To reuse Checkmate's default select behavior, call complete(todo) or complete(picker_item).
 ---@field custom_picker? fun(todos: checkmate.Todo[], complete: fun(choice: checkmate.Todo|checkmate.picker.Item|nil)): any
 

--- a/lua/checkmate/init.lua
+++ b/lua/checkmate/init.lua
@@ -1185,8 +1185,7 @@ function M.select_metadata_value(opts)
 
   -- custom picker pathway: user provides their own `custom_picker` that handles generating the choices, UI, etc.
   if custom_picker then
-    picker.with_custom_picker(context, custom_picker, apply_value_with_transaction)
-    return true
+    return picker.with_custom_picker(context, custom_picker, apply_value_with_transaction)
   end
 
   -- default pathway using config's `choices` value (table or function return) inside checkmate's picker (see `config.ui.picker`)
@@ -1459,7 +1458,9 @@ end
 ---@field range? integer[] Start and end row (0-based, inclusive). Use {0, -1} or omit for entire buffer
 ---@field filter? checkmate.FilterOpts
 ---@field picker_opts? checkmate.PickerOpts
----@field custom_picker? fun(todos: checkmate.Todo[]): any
+--- Feature-level custom picker. Existing custom_picker(todos) callbacks remain valid.
+--- To reuse Checkmate's default select behavior, call complete(todo) or complete(picker_item).
+---@field custom_picker? fun(todos: checkmate.Todo[], complete: fun(choice: checkmate.Todo|checkmate.picker.Item|nil)): any
 
 --- Opens a picker to select a todo
 ---  - Selection of a todo will jump to the todo by default
@@ -1469,15 +1470,41 @@ end
 --- a picker-specific config can be passed via `picker_opts`.
 ---
 --- **Custom Picker:**
---- Pass a `opts.custom_picker` for complete control (BYOP). You handle everything: calling the picker and then calling complete(value).
+--- Pass a `opts.custom_picker` for control over the picker UI. The first argument is
+--- the todo payload (`checkmate.Todo[]`); the second argument is a `complete` callback.
+--- Call `complete(todo)` or `complete({ text = todo.text, value = todo })` to apply
+--- Checkmate's default select-todo behavior. Call `complete(nil)` to cancel. For
+--- compatibility, existing `custom_picker(todos)` callbacks may ignore `complete`.
 --- Your function will receive:
 ---   - `todos`: array of matched todos
+---   - `complete`: callback to finish the selection
+---
+--- Example:
+--- ```lua
+--- require("checkmate").select_todo({
+---   custom_picker = function(todos, complete)
+---     vim.ui.select(todos, {
+---       prompt = "Select todo",
+---       format_item = function(todo)
+---         return todo.text
+---       end,
+---     }, complete)
+---   end,
+--- })
+--- ```
 ---
 ---@param opts? checkmate.SelectTodoOpts
 ---@return boolean success True if successful launch of the picker
 function M.select_todo(opts)
   opts = opts or {}
-  local picker = require("checkmate.picker")
+  local todo_picker = require("checkmate.todo.picker")
+  local log = require("checkmate.log")
+
+  if opts.custom_picker and not vim.is_callable(opts.custom_picker) then
+    require("checkmate.util").notify("`custom_picker` must be a function", vim.log.levels.WARN)
+    log.fmt_warn("[main] attempted to call `select_todo` with `custom_picker` not a function")
+    return false
+  end
 
   local todos = M.get_todos({
     bufnr = opts.bufnr,
@@ -1485,21 +1512,11 @@ function M.select_todo(opts)
     filter = opts.filter,
   })
 
-  if opts.custom_picker and vim.is_callable(opts.custom_picker) then
-    local custom_ok, custom_err = pcall(opts.custom_picker, todos)
-    if not custom_ok then
-      vim.notify(string.format("Checkmate: error in `custom_picker` for `select_todo`:\n%s", custom_err))
-      return false
-    end
-    return true
+  if opts.custom_picker then
+    return todo_picker.with_custom_picker(todos, opts.custom_picker)
   end
 
-  picker.pick(picker.map_items(todos, "text"), {
-    method = "pick_todo",
-    picker_opts = opts.picker_opts,
-  })
-
-  return true
+  return todo_picker.open_picker(todos, opts.picker_opts)
 end
 
 --- Lints the current Checkmate buffer according to the plugin's enabled custom linting rules

--- a/lua/checkmate/metadata/picker.lua
+++ b/lua/checkmate/metadata/picker.lua
@@ -3,10 +3,8 @@
 --- for updating metadata values
 local M = {}
 
-local parser = require("checkmate.parser")
 local meta_module = require("checkmate.metadata")
-local picker = require("checkmate.picker")
-local util = require("checkmate.util")
+local picker_util = require("checkmate.picker.util")
 local log = require("checkmate.log")
 
 --- Opens a picker for the metadata provided in context
@@ -82,43 +80,32 @@ function M.open_picker(context, apply_value_with_transaction, picker_opts)
   end
 end
 
---- Execute a user-provided custom picker function
---- The user's picker must call `user_complete_callback` with the selected value
+--- Execute a user-provided custom picker function.
 ---
---- **Callback flow**:
+--- This path is domain-level rather than picker-engine-level: the user receives
+--- metadata context and calls complete(value), where value is the metadata value
+--- to apply.
+---
+--- Callback flow:
 ---   1. Receives metadata context (todo, selected metadata) from caller
 ---   2. Builds user-facing context object
----   3. Creates `user_complete_callback` (the "complete" function user calls)
----   4. Invokes user's `custom_picker(context, user_complete_callback)`
----   5. User's picker eventually calls `user_complete_callback(value)`
----   6. `user_complete_callback` calls `apply_value_with_transaction`
+---   3. Creates `complete` (the function user calls)
+---   4. Invokes user's `custom_picker(context, complete)`
+---   5. User's picker eventually calls `complete(value)` or `complete(nil)`
+---   6. `complete(value)` calls `apply_value_with_transaction`
 ---
 ---@param context checkmate.MetadataContext
----@param custom_picker fun(context: checkmate.MetadataContext, user_complete_callback: fun(value: string?))
+---@param custom_picker fun(context: checkmate.MetadataContext, complete: fun(value: string?))
 ---@param apply_value_with_transaction fun(value: string?)
 function M.with_custom_picker(context, custom_picker, apply_value_with_transaction)
   local bufnr = context.buffer
-  local completed = false
-
-  --- Completion callback that user invokes with their selected value
-  --- This is the "complete" function passed to the user's custom_picker fn,
-  --- and the user would typically call within their picker's "confirm" or "select" action/handler
-  ---@param value string? Selected value, or nil if cancelled
-  local function user_complete_callback(value)
-    if completed then
-      log.fmt_warn("[metadata/picker] `complete` called multiple times for bufnr %d", bufnr)
-      return
-    end
-    completed = true
-
-    vim.schedule(function()
-      apply_value_with_transaction(value)
-    end)
-  end
+  local complete = picker_util.make_value_completion(apply_value_with_transaction, {
+    source = string.format("[metadata/picker] bufnr %d", bufnr),
+  })
 
   -- step 1 for the with_custom_picker path:
   -- Call the user's custom_picker fn, giving it metadata context and a `complete` callback to use
-  local success, err = pcall(custom_picker, context, user_complete_callback)
+  local success, err = pcall(custom_picker, context, complete)
 
   if not success then
     local err_msg =

--- a/lua/checkmate/metadata/picker.lua
+++ b/lua/checkmate/metadata/picker.lua
@@ -1,4 +1,7 @@
 --- Metadata picker module (internal)
+--- a "domain-picker bridge" as we refer to it in internal docs
+--- links the public metadata selection API to the generic picker engine
+---
 --- Handles both default (choices-based) and custom picker implementations
 --- for updating metadata values
 local M = {}
@@ -80,11 +83,7 @@ function M.open_picker(context, apply_value_with_transaction, picker_opts)
   end
 end
 
---- Execute a user-provided custom picker function.
----
---- This path is domain-level rather than picker-engine-level: the user receives
---- metadata context and calls complete(value), where value is the metadata value
---- to apply.
+--- Execute a user-provided custom picker function
 ---
 --- Callback flow:
 ---   1. Receives metadata context (todo, selected metadata) from caller
@@ -99,6 +98,9 @@ end
 ---@param apply_value_with_transaction fun(value: string?)
 function M.with_custom_picker(context, custom_picker, apply_value_with_transaction)
   local bufnr = context.buffer
+
+  -- the `apply_value_with_transaction` callback is where the public API
+  -- finishes the metadata value update within the transaction system
   local complete = picker_util.make_value_completion(apply_value_with_transaction, {
     source = string.format("[metadata/picker] bufnr %d", bufnr),
   })

--- a/lua/checkmate/picker/backends/mini.lua
+++ b/lua/checkmate/picker/backends/mini.lua
@@ -6,7 +6,8 @@
 local M = {}
 
 local picker_util = require("checkmate.picker.util")
-local make_choose = picker_util.make_choose
+local todo_util = require("checkmate.todo.util")
+local make_item_completion = picker_util.make_item_completion
 
 local function load_minipick()
   local ok, minipick = pcall(require, "mini.pick")
@@ -42,9 +43,7 @@ function M.pick(ctx)
     }
   end
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-  })
+  local choose = make_item_completion(ctx)
 
   local start_opts = vim.tbl_deep_extend("force", {
     source = {
@@ -84,24 +83,13 @@ function M.pick_todo(ctx)
     return e
   end
 
-  ---@type checkmate.picker.after_select
-  local function after_select(_, entry)
-    local bufnr = entry.buf
-    local row = entry.pos[1]
-
-    if bufnr and type(row) == "number" then
-      if vim.api.nvim_buf_is_valid(bufnr) then
-        if not vim.api.nvim_buf_is_loaded(bufnr) then
-          pcall(vim.fn.bufload, bufnr)
-        end
-        pcall(vim.api.nvim_set_current_buf, bufnr)
-        pcall(vim.api.nvim_win_set_cursor, 0, { row, 0 })
-      end
-    end
+  ---@type checkmate.picker.after_item_select
+  local function after_item_select(item)
+    todo_util.jump_to_todo(item.value)
     -- implicit nil return will close mini.pick
   end
 
-  local choose = make_choose(ctx, { schedule = true, after_select = after_select })
+  local choose = make_item_completion(ctx, { after_item_select = after_item_select })
 
   local start_opts = vim.tbl_deep_extend("force", {
     source = {

--- a/lua/checkmate/picker/backends/native.lua
+++ b/lua/checkmate/picker/backends/native.lua
@@ -4,8 +4,8 @@
 local M = {}
 
 local picker_util = require("checkmate.picker.util")
-local make_choose = picker_util.make_choose
-local api = vim.api
+local todo_util = require("checkmate.todo.util")
+local make_item_completion = picker_util.make_item_completion
 
 ---@param ctx checkmate.picker.AdapterContext
 function M.pick(ctx)
@@ -18,9 +18,7 @@ function M.pick(ctx)
     return item.text or ""
   end, items)
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-  })
+  local choose = make_item_completion(ctx)
 
   vim.ui.select(
     labels,
@@ -41,7 +39,7 @@ function M.pick(ctx)
         return
       end
 
-      -- pass the Item directly...`make_choose` will treat it as the resolved item
+      -- pass the Item directly; item completion treats it as the resolved item
       choose(item)
     end
   )
@@ -59,34 +57,12 @@ function M.pick_todo(ctx)
   end, items)
 
   --- Jump to the todo's buffer/row after user callback
-  local function after_select(item)
-    local todo = item.value
-    if type(todo) ~= "table" then
-      return
-    end
-
-    local bufnr = todo.bufnr
-    local row = todo.row
-
-    if not (bufnr and type(row) == "number") then
-      return
-    end
-
-    if not api.nvim_buf_is_valid(bufnr) then
-      return
-    end
-
-    if not api.nvim_buf_is_loaded(bufnr) then
-      pcall(vim.fn.bufload, bufnr)
-    end
-
-    pcall(api.nvim_set_current_buf, bufnr)
-    pcall(api.nvim_win_set_cursor, 0, { row + 1, 0 })
+  local function after_item_select(item)
+    todo_util.jump_to_todo(item.value)
   end
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-    after_select = after_select,
+  local choose = make_item_completion(ctx, {
+    after_item_select = after_item_select,
   })
 
   vim.ui.select(

--- a/lua/checkmate/picker/backends/snacks.lua
+++ b/lua/checkmate/picker/backends/snacks.lua
@@ -6,7 +6,7 @@
 local M = {}
 
 local picker_util = require("checkmate.picker.util")
-local make_choose = picker_util.make_choose
+local make_item_completion = picker_util.make_item_completion
 
 local function load_snacks()
   local ok, snacks = pcall(require, "snacks")
@@ -32,9 +32,7 @@ function M.pick(ctx)
     }
   end
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-  })
+  local choose = make_item_completion(ctx)
 
   ---@type snacks.picker.Config
   local base = {
@@ -80,9 +78,7 @@ function M.pick_todo(ctx)
     return e
   end
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-  })
+  local choose = make_item_completion(ctx)
 
   ---@type snacks.picker.Config
   local base = {

--- a/lua/checkmate/picker/backends/telescope.lua
+++ b/lua/checkmate/picker/backends/telescope.lua
@@ -6,7 +6,8 @@ local M = {}
 
 local api = vim.api
 local picker_util = require("checkmate.picker.util")
-local make_choose = picker_util.make_choose
+local todo_util = require("checkmate.todo.util")
+local make_item_completion = picker_util.make_item_completion
 
 local ns = api.nvim_create_namespace("checkmate_picker_telescope_todo")
 
@@ -65,9 +66,7 @@ function M.pick(ctx)
     }
   end
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-  })
+  local choose = make_item_completion(ctx)
 
   local opts = make_theme_opts(tel, {
     prompt_title = ctx.prompt or "Select an item",
@@ -126,31 +125,13 @@ function M.pick_todo(ctx)
     return e
   end
 
-  ---@type checkmate.picker.after_select
-  local function after_select(_, entry)
-    local bufnr = entry and entry.bufnr
-    local lnum = entry and entry.lnum
-    local col = (entry and entry.col) or 0
-
-    if not (bufnr and lnum) then
-      return
-    end
-
-    vim.schedule(function()
-      if not api.nvim_buf_is_valid(bufnr) then
-        return
-      end
-      if not api.nvim_buf_is_loaded(bufnr) then
-        pcall(vim.fn.bufload, bufnr)
-      end
-      pcall(api.nvim_set_current_buf, bufnr)
-      pcall(api.nvim_win_set_cursor, 0, { lnum, col })
-    end)
+  ---@type checkmate.picker.after_item_select
+  local function after_item_select(item)
+    todo_util.jump_to_todo(item.value)
   end
 
-  local choose = make_choose(ctx, {
-    schedule = true,
-    after_select = after_select,
+  local choose = make_item_completion(ctx, {
+    after_item_select = after_item_select,
   })
 
   local previewer = tel.previewers.new_buffer_previewer({

--- a/lua/checkmate/picker/init.lua
+++ b/lua/checkmate/picker/init.lua
@@ -1,16 +1,44 @@
 --[[
 
 Picker architecture:
-0. Feature layer (e.g. metadata/picker.lua)
-  - API specific logic, generates items, handles plugin related callbacks
-1. Picker orchestration (this module)
-  - Normalizes `items` to checkmate.picker.Item
-  - Resolves a backend with fallback to native
-  - Dispatches the correct adapter_method -> adapter
-2. Backend adapters (pickers/backends/*)
-  - Plugin-specific implementations
-  - Interface via checkmate.picker.Adapter and AdapterContext
-    - receive `checkmate.picker.Item[]`, make picker-specific entries
+
+  1. Public feature APIs
+     Examples: select_metadata_value, select_todo, etc.
+     Validates public opts, gathers domain-specific context and delegates
+     picker-specific behavior to a domain picker bridge.
+
+  2. Domain picker bridges
+     Examples: metadata/picker.lua, todo/picker.lua, etc.
+     Translates domain candidates (e.g. choices) into picker items and owns
+     feature-level `custom_picker` behavior.
+
+     A feature-level `custom_picker` receives domain payloads:
+       custom_picker(metadata_context, complete_value)
+       custom_picker(todo_list, complete_todo)
+       custom_picker(move_destinations, complete_destination)
+
+  3. Picker engine (this module)
+     Works with normalized |checkmate.picker.Item| values. It validates
+     picker opts, normalizes candidates, optionally runs picker_fn, resolves a
+     backend, and protects on_select callbacks.
+
+     `picker_fn(items, opts, complete)` is a low level override. It receives
+     normalized picker items and must call complete(item) or complete(nil). It is
+     lower-level than feature custom_picker and skips backend adapters entirely.
+
+  4. Backend adapters
+     Files: picker/backends/*.lua. Adapters translate normalized picker items to
+     plugin-specific entry shapes, preserving the original item under __cm_item
+     when they cannot pass it through directly.
+
+Good things to know:
+  - Input candidates may be strings or { text, value } items.
+  - After normalization, selection completion is Item-based.
+  - complete(nil) means cancellation.
+  - complete(item) selects at most once.
+  - picker.pick(...) returns true if a picker path was invoked/launched, false
+    for validation failure, empty item lists, picker_fn/backend failures, or
+    total fallback failure.
 
 Config merging (increasing) priority:
 For each backend:
@@ -23,14 +51,15 @@ local M = {}
 local H = {}
 
 local log = require("checkmate.log")
+local picker_util = require("checkmate.picker.util")
 
 ---@class checkmate.picker.Item
----@field text string Display text
----@field value any Payload (used as the value for callbacks)
+---@field text string Display/search text. Normalized to a string before reaching backends.
+---@field value any Non-nil payload passed as the first on_select argument. Use a table for structured candidates.
 
 ---@class checkmate.picker.PickOpts
 ---@field prompt? string
----Updates each item.text to the returned string, before being passed to the item to the backend picker.
+---Updates each item.text to the returned string, before the item is passed to the backend picker.
 ---Note, the picker implementation may also run a "format" function per item to get the display value
 ---for the finder/selection buffer.
 ---The latter should be configured via the apppropriate `picker_opts` field for that picker, if desired.
@@ -40,8 +69,9 @@ local log = require("checkmate.log")
 ---@field picker_opts? checkmate.PickerOpts
 ---@field method? checkmate.picker.Method Defaults to `pick`
 ---@field on_select? fun(value: any, item: checkmate.picker.Item)
----picker_fn is a full override. Call complete(item) on select. `item` must be a `checkmate.picker.Item`
----@field picker_fn? fun(items: checkmate.picker.Item[], opts?: checkmate.picker.PickOpts, complete: fun(choice_item: checkmate.picker.Item))
+---picker_fn is a full picker-engine override. Call complete(item) on select,
+---or complete(nil) to cancel. `item` must be a normalized checkmate.picker.Item.
+---@field picker_fn? fun(items: checkmate.picker.Item[], opts?: checkmate.picker.PickOpts, complete: fun(choice_item: checkmate.picker.Item?))
 
 ---@class checkmate.picker.AdapterContext
 ---@field items checkmate.picker.Item[]
@@ -64,60 +94,24 @@ M.METHODS = {
 ---@class checkmate.picker.Adapter
 ---@field [fun(ctx: checkmate.picker.AdapterContext)] checkmate.picker.Method
 
---- If `opts.picker_fn` is provided, it *fully overrides* the backend call
+--- If `opts.picker_fn` is provided, it fully overrides the backend call
 ---@param items (string|checkmate.picker.Item)[]
 ---@param opts? checkmate.picker.PickOpts
+---@return boolean success true when a picker path was launched or invoked successfully
 function M.pick(items, opts)
   local config = require("checkmate.config")
 
   opts = opts or {}
-  local picker_opts = opts.picker_opts or {}
 
   local valid, validate_err = H.validate_pick_opts(opts)
   if not valid then
     H.notify_err(validate_err)
-    return
+    return false
   end
 
+  local picker_opts = opts.picker_opts or {}
   local format_item_text = opts.format_item_text or H.default_format_item_text
   local norm_items = H.normalize_items(items, { formatter = format_item_text })
-
-  -- full override
-  if type(opts.picker_fn) == "function" then
-    local ok, picker_fn_err = pcall(function()
-      opts.picker_fn(norm_items, opts, function(choice_item)
-        if choice_item ~= nil then
-          if type(opts.on_select) == "function" then
-            pcall(opts.on_select, choice_item.value, choice_item)
-          end
-        end
-      end)
-    end)
-    if not ok then
-      H.notify_err("picker_fn error: " .. tostring(picker_fn_err))
-    end
-    return
-  end
-
-  -- resolve backend
-  -- - 1. per-call picker_opts.picker
-  -- - 2. config.ui.picker (global default)
-  -- - 3. auto choose a backend based on installed plugins, with fallback to vim.ui.select (native)
-  --
-  -- remember: "native" vim.ui.select can still be overriden/registered by an installed picker plugin
-  -- depending on the user's neovim config
-  local backend = vim.tbl_get(picker_opts, "picker") or vim.tbl_get(config.options, "ui", "picker")
-  if backend == nil then
-    backend = H.auto_choose_backend()
-  end
-
-  local ok, adapter = pcall(H.get_adapter, backend)
-  if not ok then
-    H.notify_err("failed to load picker backend '" .. backend .. "': " .. tostring(adapter))
-  end
-
-  -- the backend specific table resolved from picker_opts
-  local backend_opts = vim.tbl_extend("force", picker_opts.opts or {}, picker_opts[backend] or {}) or {}
 
   ---@param item checkmate.picker.Item
   local function handle_on_select(item)
@@ -135,9 +129,52 @@ function M.pick(items, opts)
     prompt = opts.prompt,
     kind = opts.kind,
     format_item_text = format_item_text,
-    backend_opts = backend_opts,
+    backend_opts = {},
     on_select_item = handle_on_select,
   }
+
+  if type(opts.picker_fn) == "function" then
+    local complete = picker_util.make_item_completion(ctx)
+    local ok, picker_fn_err = pcall(opts.picker_fn, norm_items, opts, complete)
+    if not ok then
+      H.notify_err("picker_fn error: " .. tostring(picker_fn_err))
+      return false
+    end
+    return true
+  end
+
+  -- No point in presenting an empty list? Return false to notify "nothing launched"
+  if #norm_items == 0 then
+    return false
+  end
+
+  -- resolve backend
+  -- - 1. per-call picker_opts.picker
+  -- - 2. config.ui.picker (global default)
+  -- - 3. auto choose a backend based on installed plugins, with fallback to vim.ui.select (native)
+  --
+  -- remember: "native" vim.ui.select can still be overriden/registered by an installed picker plugin
+  -- depending on the user's neovim config
+  local backend = vim.tbl_get(picker_opts, "picker") or vim.tbl_get(config.options, "ui", "picker")
+  if backend == nil then
+    backend = H.auto_choose_backend()
+  end
+
+  local ok, adapter = pcall(H.get_adapter, backend)
+  if not ok then
+    log.fmt_warn("[picker] failed to load %s backend: %s\nFalling back to native adapter.", backend, tostring(adapter))
+
+    local ok_native, native_adapter = pcall(H.get_adapter, "native")
+    if not ok_native then
+      H.notify_err("failed to load native picker backend: " .. tostring(native_adapter))
+      return false
+    end
+
+    backend = "native"
+    adapter = native_adapter
+  end
+
+  ctx.backend_opts = H.resolve_backend_opts(picker_opts, backend)
 
   -- resolve the adapter method
   ---@type checkmate.picker.Method
@@ -160,6 +197,11 @@ function M.pick(items, opts)
   local success, err = try_adapter_method(backend, method, method_name)
 
   if not success then
+    if backend == "native" then
+      H.notify_err(("picker error: native backend failed for method '%s': %s"):format(method_name, err))
+      return false
+    end
+
     log.fmt_warn(
       "[picker] attempted to call %s backend's '%s' method but failed: %s\nFalling back to native adapter with same method.",
       backend,
@@ -171,8 +213,10 @@ function M.pick(items, opts)
     local ok_native, native_adapter = pcall(H.get_adapter, "native")
     if not ok_native then
       H.notify_err("failed to load native picker backend: " .. tostring(native_adapter))
-      return
+      return false
     end
+
+    ctx.backend_opts = H.resolve_backend_opts(picker_opts, "native")
 
     local native_method = native_adapter[method_name]
     local native_success, native_err = try_adapter_method("native", native_method, method_name)
@@ -185,8 +229,13 @@ function M.pick(items, opts)
           native_err
         )
       )
+      return false
     end
+
+    return true
   end
+
+  return true
 end
 
 -- Map arbitrary tables to {text, value} items
@@ -199,9 +248,9 @@ function M.map_items(items, text_key, value_key)
     return items
   end
   return vim.tbl_map(function(i)
-    assert(i[text_key], string.format("text_key '%s' missing from item in `map_items`", text_key))
+    assert(i[text_key] ~= nil, string.format("text_key '%s' missing from item in `map_items`", text_key))
     if value_key then
-      assert(i[value_key], string.format("value_key '%s' missing from item in `map_items`", value_key))
+      assert(i[value_key] ~= nil, string.format("value_key '%s' missing from item in `map_items`", value_key))
     end
     return { text = i[text_key], value = (value_key and i[value_key] or i) }
   end, items)
@@ -219,6 +268,33 @@ function H.validate_pick_opts(opts)
 
   if opts.format_item_text and not vim.is_callable(opts.format_item_text) then
     return false, "`format_item_text` must be callable"
+  end
+
+  if opts.picker_fn ~= nil and not vim.is_callable(opts.picker_fn) then
+    return false, "`picker_fn` must be callable"
+  end
+
+  if opts.method ~= nil then
+    if type(opts.method) ~= "string" then
+      return false, "`method` must be a string"
+    end
+
+    if not vim.tbl_contains(vim.tbl_values(M.METHODS), opts.method) then
+      return false,
+        string.format(
+          "`method` must be one of: %s",
+          table.concat(
+            vim.tbl_map(function(method)
+              return string.format("'%s'", method)
+            end, vim.tbl_values(M.METHODS)),
+            ", "
+          )
+        )
+    end
+  end
+
+  if opts.picker_opts ~= nil and type(opts.picker_opts) ~= "table" then
+    return false, "`picker_opts` must be a table"
   end
 
   local must_be_one_of = string.format(
@@ -271,8 +347,15 @@ function H.normalize_items(items, opts)
     if item_type == "string" then
       item = { text = it, value = it }
     elseif item_type == "table" then
-      local text = it.text or it[1]
-      local value = it.value or it[2]
+      local text = it.text
+      if text == nil then
+        text = it[1]
+      end
+
+      local value = it.value
+      if value == nil then
+        value = it[2]
+      end
 
       if value == nil then
         value = tostring(text or "")
@@ -304,6 +387,13 @@ function H.normalize_items(items, opts)
   end
 
   return out
+end
+
+---@param picker_opts checkmate.PickerOpts
+---@param backend checkmate.Picker
+---@return table<string, any>
+function H.resolve_backend_opts(picker_opts, backend)
+  return vim.tbl_deep_extend("force", picker_opts.opts or {}, picker_opts[backend] or {})
 end
 
 ---@param item checkmate.picker.Item

--- a/lua/checkmate/picker/init.lua
+++ b/lua/checkmate/picker/init.lua
@@ -54,7 +54,7 @@ local log = require("checkmate.log")
 local picker_util = require("checkmate.picker.util")
 
 ---@class checkmate.picker.Item
----@field text string Display/search text. Normalized to a string before reaching backends.
+---@field text string Display/search text
 ---@field value any Non-nil payload passed as the first on_select argument. Use a table for structured candidates.
 
 ---@class checkmate.picker.PickOpts

--- a/lua/checkmate/picker/util.lua
+++ b/lua/checkmate/picker/util.lua
@@ -2,26 +2,68 @@ local M = {}
 
 local log = require("checkmate.log")
 
----@class checkmate.picker.MakeChooseOpts
----@field schedule? boolean
----@field after_select? fun(item: checkmate.picker.Item, entry: any)
+local function safe_fmt_warn(...)
+  pcall(log.fmt_warn, ...)
+end
 
----@alias checkmate.picker.after_select fun(item: checkmate.picker.Item, entry: any)
+local function safe_fmt_error(...)
+  pcall(log.fmt_error, ...)
+end
 
---- Create a selection handler:
---- - accepts a backend "entry" (created in the adapter code, fed to the picker as its internal representation)
---- - resolves to the original checkmate.picker.Item
---- - calls ctx.on_select_item(item) once
---- - optionally runs after_select(item, entry) for adapter specific code to run after the caller's on_select
---- - can run via vim.schedule() if `schedule=true`
+---@class checkmate.picker.CompletionCommonOpts
+---@field schedule? boolean Defaults to true. Set false only for synchronous tests or known synchronous internal paths
+---@field source? string label used in log messages
+---@field on_cancel? fun()
+
+--- Resolve a backend entry or picker completion value to the original picker item.
 ---
----@param ctx checkmate.picker.AdapterContext
----@param opts? checkmate.picker.MakeChooseOpts
----@return fun(entry: any) choose
-function M.make_choose(ctx, opts)
+--- The picker engine's completion contract is item-based: custom picker functions
+--- and adapters should call complete(item), where item is a normalized
+--- checkmate.picker.Item. Backend adapters may pass their own entry table instead
+--- as long as they preserve the normalized item under `__cm_item`.
+---@param entry any
+---@return checkmate.picker.Item|nil
+function M.resolve_item(entry)
+  if entry == nil then
+    return nil
+  end
+
+  if type(entry) ~= "table" then
+    return nil
+  end
+
+  if entry.__cm_item ~= nil then
+    return entry.__cm_item
+  end
+
+  if entry.text ~= nil and entry.value ~= nil then
+    return entry
+  end
+
+  return nil
+end
+
+---@class checkmate.picker.MakeCompletionFnOpts : checkmate.picker.CompletionCommonOpts
+---@field resolve? fun(input: any): any?
+---@field on_complete fun(value: any, input: any)
+---@field invalid_message? fun(input: any): string
+
+--- Create the shared one-shot latch used by picker selections.
+--- i.e., execute once for the initial call
+---
+--- Public wrappers below decide what a non-nil completion value means:
+--- - item completion resolves backend entries to checkmate.picker.Item
+--- - value completion accepts the domain value directly
+---@param opts checkmate.picker.MakeCompletionFnOpts
+---@return fun(input: any?) complete
+local function make_completion_fn(opts)
   opts = opts or {}
-  local schedule = opts.schedule
-  local after_select = opts.after_select
+  local schedule = opts.schedule ~= false
+  local source = opts.source or "[picker]"
+  local resolve = opts.resolve
+  local on_complete = opts.on_complete
+  local on_cancel = opts.on_cancel
+  local invalid_message = opts.invalid_message
   local completed = false
 
   local function run(fn)
@@ -32,42 +74,109 @@ function M.make_choose(ctx, opts)
     end
   end
 
-  return function(entry)
-    if completed or entry == nil then
+  return function(input)
+    if completed then
+      safe_fmt_warn("%s `complete` called multiple times", source)
       return
     end
     completed = true
 
-    ---@type checkmate.picker.Item|nil
-    local item
-
-    if type(entry) == "table" and entry.__cm_item ~= nil then
-      item = entry.__cm_item
-    else
-      -- allow native or other adapters to pass the item directly
-      item = entry
-    end
-
-    if not item then
+    if input == nil then
+      if on_cancel then
+        run(function()
+          local ok_cancel, err_cancel = pcall(on_cancel)
+          if not ok_cancel then
+            safe_fmt_error("%s cancel callback failed: %s", source, tostring(err_cancel))
+          end
+        end)
+      end
       return
     end
 
-    run(function()
-      if ctx.on_select_item then
-        local ok_sel, err_sel = pcall(ctx.on_select_item, item)
-        if not ok_sel then
-          log.fmt_error("[picker] on_select_item failed: %s", tostring(err_sel))
+    local value = input
+    if resolve then
+      value = resolve(input)
+      if value == nil then
+        if invalid_message then
+          safe_fmt_warn("%s", invalid_message(input))
+        else
+          safe_fmt_warn("%s invalid completion value: %s", source, vim.inspect(input))
         end
+        return
       end
+    end
 
-      if after_select then
-        local ok_after, err_after = pcall(after_select, item, entry)
-        if not ok_after then
-          log.fmt_error("[picker] after_select failed: %s", tostring(err_after))
-        end
+    run(function()
+      local ok_complete, err_complete = pcall(on_complete, value, input)
+      if not ok_complete then
+        safe_fmt_error("%s complete callback failed: %s", source, tostring(err_complete))
       end
     end)
   end
+end
+
+---@class checkmate.picker.MakeItemCompletionOpts : checkmate.picker.CompletionCommonOpts
+---@field after_item_select? fun(item: checkmate.picker.Item, entry: any)
+
+---@alias checkmate.picker.after_item_select fun(item: checkmate.picker.Item, entry: any)
+
+--- Create an item completion callback for picker-engine/backend selections
+---
+--- Accepts a normalized checkmate.picker.Item or backend entry with __cm_item.
+--- Nil cancels. Invalid non-nil completions are ignored with a warning
+---@param ctx checkmate.picker.AdapterContext
+---@param opts? checkmate.picker.MakeItemCompletionOpts
+---@return fun(entry: any) complete
+function M.make_item_completion(ctx, opts)
+  opts = opts or {}
+  local after_item_select = opts.after_item_select
+
+  return make_completion_fn({
+    schedule = opts.schedule,
+    source = opts.source or "[picker]",
+    on_cancel = opts.on_cancel,
+    resolve = M.resolve_item,
+    invalid_message = function(entry)
+      return ("[picker] complete called with invalid picker item: %s"):format(vim.inspect(entry))
+    end,
+    on_complete = function(item, entry)
+      if ctx.on_select_item then
+        local ok_sel, err_sel = pcall(ctx.on_select_item, item)
+        if not ok_sel then
+          safe_fmt_error("[picker] on_select_item failed: %s", tostring(err_sel))
+        end
+      end
+
+      if after_item_select then
+        local ok_after, err_after = pcall(after_item_select, item, entry)
+        if not ok_after then
+          safe_fmt_error("[picker] after_item_select failed: %s", tostring(err_after))
+        end
+      end
+    end,
+  })
+end
+
+---@class checkmate.picker.MakeValueCompletionOpts : checkmate.picker.CompletionCommonOpts
+
+--- Create a value completion callback for feature-level custom pickers
+---
+--- Accepts the selected domain value directly: a metadata value, a move target,
+--- or any other feature-owned payload. Nil cancels
+---@param on_complete fun(value: any)
+---@param opts? checkmate.picker.MakeValueCompletionOpts
+---@return fun(value: any?) complete
+function M.make_value_completion(on_complete, opts)
+  opts = opts or {}
+
+  return make_completion_fn({
+    schedule = opts.schedule,
+    source = opts.source or "[picker]",
+    on_cancel = opts.on_cancel,
+    on_complete = function(value)
+      on_complete(value)
+    end,
+  })
 end
 
 return M

--- a/lua/checkmate/picker/util.lua
+++ b/lua/checkmate/picker/util.lua
@@ -2,14 +2,6 @@ local M = {}
 
 local log = require("checkmate.log")
 
-local function safe_fmt_warn(...)
-  pcall(log.fmt_warn, ...)
-end
-
-local function safe_fmt_error(...)
-  pcall(log.fmt_error, ...)
-end
-
 ---@class checkmate.picker.CompletionCommonOpts
 ---@field schedule? boolean Defaults to true. Set false only for synchronous tests or known synchronous internal paths
 ---@field source? string label used in log messages
@@ -37,6 +29,7 @@ function M.resolve_item(entry)
   end
 
   if entry.text ~= nil and entry.value ~= nil then
+    -- has shape of checkmate.picker.Item, okay to return
     return entry
   end
 
@@ -76,7 +69,7 @@ local function make_completion_fn(opts)
 
   return function(input)
     if completed then
-      safe_fmt_warn("%s `complete` called multiple times", source)
+      log.fmt_warn("%s `complete` called multiple times", source)
       return
     end
     completed = true
@@ -86,7 +79,7 @@ local function make_completion_fn(opts)
         run(function()
           local ok_cancel, err_cancel = pcall(on_cancel)
           if not ok_cancel then
-            safe_fmt_error("%s cancel callback failed: %s", source, tostring(err_cancel))
+            log.fmt_error("%s cancel callback failed: %s", source, tostring(err_cancel))
           end
         end)
       end
@@ -98,9 +91,9 @@ local function make_completion_fn(opts)
       value = resolve(input)
       if value == nil then
         if invalid_message then
-          safe_fmt_warn("%s", invalid_message(input))
+          log.fmt_warn("%s", invalid_message(input))
         else
-          safe_fmt_warn("%s invalid completion value: %s", source, vim.inspect(input))
+          log.fmt_warn("%s invalid completion value: %s", source, vim.inspect(input))
         end
         return
       end
@@ -109,7 +102,7 @@ local function make_completion_fn(opts)
     run(function()
       local ok_complete, err_complete = pcall(on_complete, value, input)
       if not ok_complete then
-        safe_fmt_error("%s complete callback failed: %s", source, tostring(err_complete))
+        log.fmt_error("%s complete callback failed: %s", source, tostring(err_complete))
       end
     end)
   end
@@ -143,14 +136,14 @@ function M.make_item_completion(ctx, opts)
       if ctx.on_select_item then
         local ok_sel, err_sel = pcall(ctx.on_select_item, item)
         if not ok_sel then
-          safe_fmt_error("[picker] on_select_item failed: %s", tostring(err_sel))
+          log.fmt_error("[picker] on_select_item failed: %s", tostring(err_sel))
         end
       end
 
       if after_item_select then
         local ok_after, err_after = pcall(after_item_select, item, entry)
         if not ok_after then
-          safe_fmt_error("[picker] after_item_select failed: %s", tostring(err_after))
+          log.fmt_error("[picker] after_item_select failed: %s", tostring(err_after))
         end
       end
     end,

--- a/lua/checkmate/todo/picker.lua
+++ b/lua/checkmate/todo/picker.lua
@@ -1,5 +1,6 @@
 --- Todo picker module (internal)
---- Bridges the public todo-selection API to the generic picker engine
+--- a "domain-picker bridge" as we refer to it in internal docs
+--- links the public todo-selection API to the generic picker engine
 local M = {}
 
 local picker = require("checkmate.picker")

--- a/lua/checkmate/todo/picker.lua
+++ b/lua/checkmate/todo/picker.lua
@@ -1,0 +1,79 @@
+--- Todo picker module (internal)
+--- Bridges the public todo-selection API to the generic picker engine
+local M = {}
+
+local picker = require("checkmate.picker")
+local picker_util = require("checkmate.picker.util")
+local todo_util = require("checkmate.todo.util")
+
+--- Normalize a feature-level custom picker result into a picker item
+---
+--- select_todo custom pickers are domain-level, so they may call
+--- complete(todo) with a raw checkmate.Todo. Internally we still complete through
+--- the picker engine's Item-based shape
+---@param choice checkmate.Todo|checkmate.picker.Item|nil
+---@return checkmate.picker.Item|nil|any
+local function normalize_custom_choice(choice)
+  if choice == nil then
+    return nil
+  end
+
+  local item = picker_util.resolve_item(choice)
+  if item then
+    return item
+  end
+
+  if type(choice) == "table" and choice.bufnr and type(choice.row) == "number" then
+    return {
+      text = tostring(choice.text or ""),
+      value = choice,
+    }
+  end
+
+  return choice
+end
+
+--- Open the default todo picker
+---@param todos checkmate.Todo[]
+---@param picker_opts? checkmate.PickerOpts
+---@return boolean success
+function M.open_picker(todos, picker_opts)
+  local items = picker.map_items(todos, "text")
+
+  return picker.pick(items, {
+    method = "pick_todo",
+    picker_opts = picker_opts,
+  })
+end
+
+--- Execute a user-provided todo custom picker
+---@param todos checkmate.Todo[]
+---@param custom_picker fun(todos: checkmate.Todo[], complete: fun(choice: checkmate.Todo|checkmate.picker.Item|nil))
+---@return boolean success
+function M.with_custom_picker(todos, custom_picker)
+  local items = picker.map_items(todos, "text")
+  local choose = picker_util.make_item_completion({
+    items = items,
+    backend_opts = {},
+    format_item_text = function(item)
+      return item.text or ""
+    end,
+    on_select_item = function(item)
+      todo_util.jump_to_todo(item.value)
+    end,
+  })
+
+  local function complete(choice)
+    choose(normalize_custom_choice(choice))
+  end
+
+  local custom_ok, custom_err = pcall(custom_picker, todos, complete)
+  if not custom_ok then
+    vim.notify(string.format("Checkmate: error in `custom_picker` for `select_todo`:\n%s", custom_err))
+    return false
+  end
+
+  return true
+end
+
+return M

--- a/lua/checkmate/todo/util.lua
+++ b/lua/checkmate/todo/util.lua
@@ -1,0 +1,42 @@
+--- Shared todo helpers.
+local M = {}
+
+local api = vim.api
+
+--- Jump to a todo's source buffer and row.
+---
+--- `checkmate.Todo.row` is zero-based because it comes from parser positions;
+--- Neovim window cursors are one-based.
+---@param todo checkmate.Todo|any
+---@return boolean success
+function M.jump_to_todo(todo)
+  if type(todo) ~= "table" then
+    return false
+  end
+
+  local bufnr = todo.bufnr
+  local row = todo.row
+  local col = type(todo.col) == "number" and todo.col or 0
+
+  if not (bufnr and type(row) == "number") then
+    return false
+  end
+
+  if not api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+
+  if not api.nvim_buf_is_loaded(bufnr) then
+    pcall(vim.fn.bufload, bufnr)
+  end
+
+  local ok_buf = pcall(api.nvim_set_current_buf, bufnr)
+  if not ok_buf then
+    return false
+  end
+
+  local ok_cursor = pcall(api.nvim_win_set_cursor, 0, { row + 1, col })
+  return ok_cursor
+end
+
+return M

--- a/lua/checkmate/todo/util.lua
+++ b/lua/checkmate/todo/util.lua
@@ -1,12 +1,11 @@
---- Shared todo helpers.
 local M = {}
 
 local api = vim.api
 
---- Jump to a todo's source buffer and row.
+--- Jump to a todo's source buffer and row
 ---
---- `checkmate.Todo.row` is zero-based because it comes from parser positions;
---- Neovim window cursors are one-based.
+--- `checkmate.Todo.row` is 0 because it comes from parser positions
+--- Nvim window cursors are 1-based
 ---@param todo checkmate.Todo|any
 ---@return boolean success
 function M.jump_to_todo(todo)

--- a/tests/checkmate/picker_spec.lua
+++ b/tests/checkmate/picker_spec.lua
@@ -5,6 +5,87 @@ describe("Picker", function()
   ---@module "checkmate.picker"
   local picker
 
+  local function setup_picker_buffer(ui_picker)
+    ---@diagnostic disable-next-line: missing-fields
+    h.cm_setup({
+      ui = {
+        picker = ui_picker,
+      },
+    })
+    return h.setup_test_buffer({})
+  end
+
+  local function run_named_case(name, fn)
+    local ok, err = pcall(fn)
+    if not ok then
+      error(("%s: %s"):format(tostring(name), tostring(err)), 0)
+    end
+  end
+
+  local function with_picker_buffer(ui_picker, fn)
+    local bufnr = setup_picker_buffer(ui_picker)
+    local ok, err = pcall(fn, bufnr)
+    h.cleanup_test(bufnr)
+    if not ok then
+      error(err)
+    end
+  end
+
+  local function with_checkmate_buffer(content, fn)
+    local bufnr, cm = h.setup_checkmate_test_buffer(content)
+    local ok, err = pcall(fn, bufnr, cm)
+    h.cleanup_test(bufnr)
+    if not ok then
+      error(err)
+    end
+  end
+
+  local function with_native_select(handler, fn)
+    local ui_select_stub = stub(vim.ui, "select", function(items, opts, on_choice)
+      handler(items, opts, on_choice)
+    end)
+
+    local ok, err = pcall(fn)
+    ui_select_stub:revert()
+    if not ok then
+      error(err)
+    end
+  end
+
+  local function with_loaded_module(name, value, fn)
+    local original = package.loaded[name]
+    package.loaded[name] = value
+
+    local ok, err = pcall(fn)
+    package.loaded[name] = original
+    if not ok then
+      error(err)
+    end
+  end
+
+  local function with_preload(name, value, fn)
+    local original = package.preload[name]
+    package.preload[name] = value
+
+    local ok, err = pcall(fn)
+    package.preload[name] = original
+    if not ok then
+      error(err)
+    end
+  end
+
+  local function with_metadata_value_at_cursor(fn)
+    local unchecked = h.get_unchecked_marker()
+
+    with_checkmate_buffer({ "- " .. unchecked .. " Task @priority(low)" }, function(bufnr, cm)
+      local line = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)[1]
+      local col = h.exists(line:find("@priority")) - 1
+      vim.api.nvim_win_set_cursor(0, { 1, col })
+
+      fn(bufnr, cm, unchecked)
+    end)
+  end
+
   lazy_setup(function()
     -- suppress echo
     stub(vim.api, "nvim_echo")
@@ -24,456 +105,760 @@ describe("Picker", function()
     h.ensure_normal_mode()
   end)
 
-  it("should deep merge picker_opts.opts with picker_opts[backend]", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "snacks",
-      },
-    })
-    h.setup_test_buffer({})
+  describe("backend resolution and options", function()
+    it("deep merges picker_opts.opts with picker_opts[backend]", function()
+      with_picker_buffer("snacks", function()
+        local backend = require("checkmate.picker.backends.snacks")
+        local original_pick = backend.pick
+        local received_ctx
 
-    local backend = require("checkmate.picker.backends.snacks")
-    local received_ctx
+        backend.pick = function(ctx)
+          received_ctx = ctx
+          ctx.on_select_item(ctx.items[1])
+        end
 
-    local orig_pick = backend.pick
-    backend.pick = function(ctx)
-      received_ctx = ctx
-      ctx.on_select_item(ctx.items[1])
-    end
+        finally(function()
+          backend.pick = original_pick
+        end)
 
-    picker.pick({ "item" }, {
-      picker_opts = {
-        opts = {
-          title = "Pick One",
-          layout = "sidebar",
+        local launched = picker.pick({ "item" }, {
+          picker_opts = {
+            opts = {
+              title = "Pick One",
+              layout = "sidebar",
+              win = {
+                border = "rounded",
+                height = 20,
+              },
+            },
+            snacks = {
+              layout = "ivy",
+              previewer = true,
+              win = {
+                height = 10,
+              },
+            },
+          },
+        })
+
+        assert.is_true(launched)
+        assert.is_table(received_ctx.backend_opts)
+        assert.equal("ivy", received_ctx.backend_opts.layout)
+        assert.equal(true, received_ctx.backend_opts.previewer)
+        assert.equal("Pick One", received_ctx.backend_opts.title)
+        assert.equal("rounded", received_ctx.backend_opts.win.border)
+        assert.equal(10, received_ctx.backend_opts.win.height)
+      end)
+    end)
+
+    it("routes through native for configured, auto-detected, and per-call override paths", function()
+      local cases = {
+        {
+          name = "configured native",
+          config_picker = "native",
+          items = { "a", "b", "c" },
+          expected_len = 3,
+          expected_value = "a",
         },
-        snacks = {
-          layout = "ivy",
-          previewer = true,
+        {
+          name = "auto-detected native",
+          config_picker = nil,
+          items = { "a", "b", "c" },
+          expected_len = 3,
+          expected_value = "a",
+          assert_no_plugins = true,
         },
-      },
-    })
-
-    assert.is_table(received_ctx.backend_opts)
-    -- backend-specific opts should override picker.opts
-    assert.equal("ivy", received_ctx.backend_opts.layout)
-    assert.equal(true, received_ctx.backend_opts.previewer)
-    assert.equal("Pick One", received_ctx.backend_opts.title)
-
-    backend.pick = orig_pick
-  end)
-
-  it("should use native vim.ui.select when ui.picker is 'native'", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "native",
-      },
-    })
-    h.setup_test_buffer({})
-
-    local select_received_items
-
-    local ui_select_stub = stub(vim.ui, "select", function(items, _, on_choice)
-      select_received_items = items
-      on_choice(items[1], 1)
-    end)
-
-    local got
-    picker.pick({ "a", "b", "c" }, {
-      on_select = function(v)
-        got = v
-      end,
-    })
-
-    vim.wait(100, function()
-      return got ~= nil
-    end)
-
-    assert.is_table(select_received_items)
-    assert.equal(3, #select_received_items)
-    assert.equal("a", got)
-
-    finally(function()
-      ui_select_stub:revert()
-    end)
-  end)
-
-  it("should use native vim.ui.select when ui.picker is nil (and no other picker plugins installed)", function()
-    assert.is_false(pcall(require, "telescope"))
-    assert.is_false(pcall(require, "snacks"))
-    assert.is_false(pcall(require, "mini"))
-
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = nil,
-      },
-    })
-    h.setup_test_buffer({})
-
-    local select_received_items
-
-    local ui_select_stub = stub(vim.ui, "select", function(items, _, on_choice)
-      select_received_items = items
-      on_choice(items[1], 1)
-    end)
-
-    picker.pick({ "a", "b", "c" })
-
-    assert.is_table(select_received_items)
-    assert.equal(3, #select_received_items)
-
-    finally(function()
-      ui_select_stub:revert()
-    end)
-  end)
-
-  it("should use correct backend when ui.picker is 'telescope', 'snacks', or 'mini'", function()
-    local backends = { "telescope", "snacks", "mini" }
-    for _, backend_name in ipairs(backends) do
-      ---@diagnostic disable-next-line: missing-fields
-      h.cm_setup({
-        ui = {
-          picker = backend_name,
+        {
+          name = "picker_opts override",
+          config_picker = "snacks",
+          items = { "x", "y" },
+          opts = {
+            picker_opts = {
+              picker = "native",
+            },
+          },
+          expected_len = 2,
+          expected_value = "x",
         },
-      })
-      local bufnr = h.setup_test_buffer({})
+      }
 
-      -- should not be called
-      local spy_ui_select = spy.on(vim.ui, "select")
+      for _, tc in ipairs(cases) do
+        run_named_case(tc.name, function()
+          if tc.assert_no_plugins then
+            assert.is_false(pcall(require, "telescope"))
+            assert.is_false(pcall(require, "snacks"))
+            assert.is_false(pcall(require, "mini"))
+          end
 
-      local backend = require("checkmate.picker.backends." .. backend_name)
+          with_picker_buffer(tc.config_picker, function()
+            local received_items
+            local selected
+            local launched
 
-      local called_ctx ---@type checkmate.picker.AdapterContext
-      local orig_backend_pick = backend.pick
+            with_native_select(function(items, _, on_choice)
+              received_items = items
+              on_choice(items[1], 1)
+            end, function()
+              local opts = vim.tbl_deep_extend("force", {}, tc.opts or {})
+              opts.on_select = function(value)
+                selected = value
+              end
 
-      backend.pick = function(ctx)
-        called_ctx = ctx
+              launched = picker.pick(tc.items, opts)
+            end)
 
-        assert.is_table(ctx.items)
-        assert.equal(3, #ctx.items)
+            assert.is_true(launched)
+            assert.is_table(received_items)
+            assert.equal(tc.expected_len, #received_items)
+            vim.wait(100, function()
+              return selected ~= nil
+            end)
+            assert.equal(tc.expected_value, selected)
+          end)
+        end)
+      end
+    end)
 
-        assert.same("a", ctx.items[1].text)
-        assert.same("a", ctx.items[1].value)
-        assert.same("b", ctx.items[2].text)
-        assert.same("b", ctx.items[2].value)
-        assert.same("c", ctx.items[3].text)
-        assert.same("c", ctx.items[3].value)
+    it("dispatches normalized items and backend opts to configured plugin adapters", function()
+      for _, backend_name in ipairs({ "telescope", "snacks", "mini" }) do
+        run_named_case(backend_name, function()
+          with_picker_buffer(backend_name, function()
+            local spy_ui_select = spy.on(vim.ui, "select")
+            local backend = require("checkmate.picker.backends." .. backend_name)
+            local original_pick = backend.pick
+            local called_ctx
 
-        assert.is_function(ctx.on_select_item)
+            backend.pick = function(ctx)
+              called_ctx = ctx
+              ctx.on_select_item(ctx.items[1])
+            end
 
-        ctx.on_select_item(ctx.items[1])
+            local ok, err = pcall(function()
+              local selected_value
+              local selected_item
+
+              local launched = picker.pick({ "a", "b", "c" }, {
+                on_select = function(value, item)
+                  selected_value = value
+                  selected_item = item
+                end,
+                picker_opts = {
+                  [backend_name] = { title = "Picker" },
+                },
+              })
+
+              assert.spy(spy_ui_select).called(0)
+              assert.is_true(launched)
+              assert.is_table(called_ctx.items)
+              assert.same({
+                { text = "a", value = "a" },
+                { text = "b", value = "b" },
+                { text = "c", value = "c" },
+              }, called_ctx.items)
+              assert.is_function(called_ctx.on_select_item)
+              assert.equal("a", selected_value)
+              assert.same({ text = "a", value = "a" }, selected_item)
+              assert.equal("Picker", called_ctx.backend_opts.title)
+            end)
+
+            backend.pick = original_pick
+            spy_ui_select:revert()
+            if not ok then
+              error(err)
+            end
+          end)
+        end)
+      end
+    end)
+
+    it("auto-detects an available picker backend before falling back to native", function()
+      with_loaded_module("snacks", { picker = {} }, function()
+        with_loaded_module("checkmate.picker.backends.snacks", {
+          pick = function(ctx)
+            ctx.on_select_item(ctx.items[1])
+          end,
+        }, function()
+          with_picker_buffer(nil, function()
+            local spy_ui_select = spy.on(vim.ui, "select")
+            local selected
+
+            finally(function()
+              spy_ui_select:revert()
+            end)
+
+            local launched = picker.pick({ "a", "b" }, {
+              on_select = function(value)
+                selected = value
+              end,
+            })
+
+            assert.spy(spy_ui_select).called(0)
+            assert.is_true(launched)
+            assert.equal("a", selected)
+          end)
+        end)
+      end)
+    end)
+
+    it("falls back to native when configured backends are unavailable or fail", function()
+      local function assert_native_fallback(setup_mock)
+        setup_mock(function()
+          with_picker_buffer("snacks", function()
+            local ran_native = false
+            local selected
+            local launched
+
+            with_native_select(function(items, _, on_choice)
+              ran_native = true
+              on_choice(items[1], 1)
+            end, function()
+              local ok
+              ok, launched = pcall(function()
+                return picker.pick({ "fallback" }, {
+                  on_select = function(value)
+                    selected = value
+                  end,
+                })
+              end)
+
+              assert.is_true(ok)
+            end)
+
+            assert.is_true(launched)
+            assert.is_true(ran_native)
+            vim.wait(100, function()
+              return selected ~= nil
+            end)
+            assert.equal("fallback", selected)
+          end)
+        end)
       end
 
-      local selected_value
-      local selected_item
-      picker.pick({ "a", "b", "c" }, {
-        on_select = function(v, i)
-          selected_value = v
-          selected_item = i
-        end,
-        picker_opts = {
-          [backend_name] = { title = "Picker" },
-        },
-      })
-
-      vim.wait(100, function()
-        return selected_value ~= nil
+      assert_native_fallback(function(run)
+        with_loaded_module("snacks", nil, run)
       end)
 
-      assert.spy(spy_ui_select).called(0)
-      -- on_select should receive the value from normalized item
-      assert.equal("a", selected_value)
-      -- on_select should receive the checkmate.picker.Item as 2nd arg
-      assert.same({ text = "a", value = "a" }, selected_item)
-      -- assert some backend_opts were received
-      assert.is_table(called_ctx.backend_opts)
-      assert.equal("Picker", called_ctx.backend_opts.title)
+      assert_native_fallback(function(run)
+        with_loaded_module("snacks", { picker = {} }, function()
+          with_loaded_module("checkmate.picker.backends.snacks", {
+            pick = function()
+              error("BOOM")
+            end,
+          }, run)
+        end)
+      end)
 
-      h.cleanup_test(bufnr)
-      spy_ui_select:revert()
-      backend.pick = orig_backend_pick
-    end
-  end)
-
-  it("should use specific backend when available and config.ui.picker is nil", function()
-    -- mock snacks and backend/snacks
-    package.loaded["snacks"] = { picker = {} }
-    package.loaded["checkmate.picker.backends.snacks"] = {
-      pick = function(ctx)
-        ctx.on_select_item(ctx.items[1])
-      end,
-    }
-
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = nil, -- nil means auto-detect
-      },
-    })
-    h.setup_test_buffer({})
-
-    local spy_ui_select = spy.on(vim.ui, "select")
-
-    local selected
-    picker.pick({ "a", "b" }, {
-      on_select = function(v)
-        selected = v
-      end,
-    })
-
-    vim.wait(100, function()
-      return selected ~= nil
-    end)
-
-    -- should NOT use native vim.ui.select
-    assert.spy(spy_ui_select).called(0)
-    assert.equal("a", selected)
-
-    finally(function()
-      spy_ui_select:revert()
-      package.loaded["snacks"] = nil
-      package.loaded["checkmate.picker.backends.snacks"] = nil
+      assert_native_fallback(function(run)
+        local backend_name = "checkmate.picker.backends.snacks"
+        with_loaded_module(backend_name, nil, function()
+          with_preload(backend_name, function()
+            error("adapter load failed")
+          end, run)
+        end)
+      end)
     end)
   end)
 
-  it("should fallback to native when configured backend is not available", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "snacks",
-      },
-    })
+  describe("picker_fn and completion contracts", function()
+    it("uses picker_fn instead of backend adapters", function()
+      ---@diagnostic disable-next-line: missing-fields
+      h.cm_setup({ ui = { picker = "snacks" } })
 
-    local orig_snacks = package.loaded["snacks"]
-    package.loaded["snacks"] = nil
+      local backend = require("checkmate.picker.backends.snacks")
+      local spy_backend_pick = spy.on(backend, "pick")
+      local seen_items
+      local selected
 
-    h.setup_test_buffer({})
+      finally(function()
+        spy_backend_pick:revert()
+      end)
 
-    local select_called = false
-    local ui_select_stub = stub(vim.ui, "select", function(items, _, on_choice)
-      select_called = true
-      on_choice(items[1], 1)
-    end)
-
-    local selected
-    picker.pick({ "fallback" }, {
-      on_select = function(v)
-        selected = v
-      end,
-    })
-
-    vim.wait(100, function()
-      return selected ~= nil
-    end)
-
-    assert.is_true(select_called)
-    assert.equal("fallback", selected)
-
-    finally(function()
-      ui_select_stub:revert()
-      package.loaded["snacks"] = orig_snacks
-    end)
-  end)
-
-  it("should use picker_fn override instead of backend", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({ ui = { picker = "telescope" } })
-
-    local backend = require("checkmate.picker.backends.snacks")
-
-    local spy_backend_pick = spy.on(backend, "pick")
-
-    local seen_items
-    local selected
-    picker.pick({ "a", "b" }, {
-      picker_fn = function(items, _, done)
-        seen_items = items
-        done(items[2])
-      end,
-      on_select = function(v)
-        selected = v
-      end,
-    })
-
-    assert.spy(spy_backend_pick).called(0)
-    assert.is_table(seen_items)
-    assert.equal(2, #seen_items)
-    assert.equal("b", selected)
-
-    finally(function()
-      spy_backend_pick:revert()
-    end)
-  end)
-
-  it("should allow picker_opts.picker to override config.ui.picker", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        -- should use native despite config saying snacks
-        picker = "snacks",
-      },
-    })
-    h.setup_test_buffer({})
-
-    local select_received_items
-    local ui_select_stub = stub(vim.ui, "select", function(items, _, on_choice)
-      select_received_items = items
-      on_choice(items[1], 1)
-    end)
-
-    local got
-    picker.pick({ "x", "y" }, {
-      picker_opts = {
-        picker = "native", -- override to native
-      },
-      on_select = function(v)
-        got = v
-      end,
-    })
-
-    vim.wait(100, function()
-      return got ~= nil
-    end)
-
-    assert.is_table(select_received_items)
-    assert.equal(2, #select_received_items)
-    assert.equal("x", got)
-
-    finally(function()
-      ui_select_stub:revert()
-    end)
-  end)
-
-  it("should handle empty items array gracefully", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "native",
-      },
-    })
-    h.setup_test_buffer({})
-
-    local select_called = false
-    local ui_select_stub = stub(vim.ui, "select", function(_, _, on_choice)
-      select_called = true
-      on_choice(nil)
-    end)
-
-    local on_select_called = false
-    -- empty items
-    picker.pick({}, {
-      on_select = function()
-        on_select_called = true
-      end,
-    })
-
-    assert.is_false(select_called)
-    -- on_select should not be called
-    assert.is_false(on_select_called)
-
-    finally(function()
-      ui_select_stub:revert()
-    end)
-  end)
-
-  it("should handle items with nil values gracefully", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "native",
-      },
-    })
-    h.setup_test_buffer({})
-
-    local received_items
-    package.loaded["checkmate.picker.backends.native"] = {
-      pick = function(ctx)
-        received_items = ctx.items
-        ctx.on_select_item(ctx.items[1])
-      end,
-    }
-
-    -- item with nil value should be normalized to {text, value=text}
-    picker.pick({ { text = "display" } })
-
-    assert.is_table(received_items)
-    assert.equal(1, #received_items)
-    assert.same({ text = "display", value = "display" }, received_items[1])
-
-    finally(function()
-      package.loaded["checkmate.picker.backends.native"] = nil
-    end)
-  end)
-
-  it("should handle on_select callback errors gracefully", function()
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "native",
-      },
-    })
-    h.setup_test_buffer({})
-
-    local ui_select_stub = stub(vim.ui, "select", function(items, _, on_choice)
-      on_choice(items[1])
-    end)
-
-    -- dont throw when on_select errors
-    local did_complete = false
-    local ok = pcall(function()
-      picker.pick({ "item" }, {
-        on_select = function()
-          error("BOOM")
+      local launched = picker.pick({ "a", "b" }, {
+        picker_fn = function(items, _, complete)
+          seen_items = items
+          complete(items[2])
+        end,
+        on_select = function(value)
+          selected = value
         end,
       })
-      did_complete = true
+
+      assert.spy(spy_backend_pick).called(0)
+      assert.is_true(launched)
+      assert.same({
+        { text = "a", value = "a" },
+        { text = "b", value = "b" },
+      }, seen_items)
+      vim.wait(100, function()
+        return selected ~= nil
+      end)
+      assert.equal("b", selected)
     end)
 
-    assert.is_true(ok)
-    assert.is_true(did_complete)
+    it("enforces picker_fn launch, cancellation, one-shot, and invalid completion behavior", function()
+      local cases = {
+        {
+          name = "nil cancels and wins",
+          picker_fn = function(items, _, complete)
+            complete(nil)
+            complete(items[1])
+          end,
+          launched = true,
+          selections = {},
+        },
+        {
+          name = "first item completion wins",
+          picker_fn = function(items, _, complete)
+            complete(items[1])
+            complete(items[2])
+          end,
+          launched = true,
+          selections = { "a" },
+        },
+        {
+          name = "invalid completion is ignored",
+          picker_fn = function(_, _, complete)
+            complete("a")
+          end,
+          launched = true,
+          selections = {},
+        },
+        {
+          name = "picker_fn error returns false",
+          picker_fn = function()
+            error("BOOM")
+          end,
+          launched = false,
+          selections = {},
+        },
+      }
 
-    finally(function()
-      ui_select_stub:revert()
+      for _, tc in ipairs(cases) do
+        run_named_case(tc.name, function()
+          with_picker_buffer("native", function()
+            local selections = {}
+            local launched
+            local ok = pcall(function()
+              launched = picker.pick({ "a", "b" }, {
+                picker_fn = tc.picker_fn,
+                on_select = function(value)
+                  selections[#selections + 1] = value
+                end,
+              })
+            end)
+
+            assert.is_true(ok)
+            assert.equal(tc.launched, launched)
+            if #tc.selections > 0 then
+              vim.wait(100, function()
+                return #selections == #tc.selections
+              end)
+            end
+            assert.same(tc.selections, selections)
+          end)
+        end)
+      end
+    end)
+
+    it("keeps completion helpers one-shot, scheduled by default, and error-safe", function()
+      local picker_util = require("checkmate.picker.util")
+      local selected
+      local scheduled
+      local item = { text = "a", value = { id = 1 } }
+      local entry = { __cm_item = item }
+      local events = {}
+
+      picker_util.make_item_completion({
+        items = { item },
+        backend_opts = {},
+        format_item_text = function(value)
+          return value.text
+        end,
+        on_select_item = function(value)
+          events[#events + 1] = { "select", value }
+        end,
+      }, {
+        schedule = false,
+        after_item_select = function(value, selected_entry)
+          events[#events + 1] = { "after", value, selected_entry }
+        end,
+      })(entry)
+
+      assert.same({
+        { "select", item },
+        { "after", item, entry },
+      }, events)
+
+      local complete = picker_util.make_value_completion(function(value)
+        selected = value
+      end, {
+        schedule = false,
+        source = "[test]",
+      })
+
+      complete(nil)
+      complete("later")
+      assert.is_nil(selected)
+
+      picker_util.make_value_completion(function(value)
+        scheduled = value
+      end, {
+        source = "[test]",
+      })("queued")
+
+      assert.is_nil(scheduled)
+      vim.wait(100, function()
+        return scheduled == "queued"
+      end)
+      assert.equal("queued", scheduled)
+
+      local ok = pcall(function()
+        picker_util.make_value_completion(function()
+          error("BOOM")
+        end, {
+          schedule = false,
+          source = "[test]",
+        })("value")
+      end)
+
+      assert.is_true(ok)
     end)
   end)
 
-  it("should handle backend pick errors gracefully", function()
-    -- mock snacks and backend/snacks
-    package.loaded["snacks"] = { picker = {} }
-    package.loaded["checkmate.picker.backends.snacks"] = {
-      pick = function(_)
-        error("BOOM")
-      end,
-    }
+  describe("item normalization and callback safety", function()
+    it("preserves structured, false, fallback, and formatted item values", function()
+      local native_backend = "checkmate.picker.backends.native"
 
-    local ran_native = false
-    local ui_select_stub = stub(vim.ui, "select", function(items, _, on_choice)
-      ran_native = true
-      on_choice(items[1])
+      local cases = {
+        {
+          name = "structured value",
+          input = {
+            {
+              text = "Heading: Inbox",
+              value = {
+                kind = "heading",
+                destination = {
+                  heading = { title = "Inbox", level = 2 },
+                },
+              },
+            },
+          },
+          expected_item = {
+            text = "Heading: Inbox",
+            value = {
+              kind = "heading",
+              destination = {
+                heading = { title = "Inbox", level = 2 },
+              },
+            },
+          },
+          expected_value = {
+            kind = "heading",
+            destination = {
+              heading = { title = "Inbox", level = 2 },
+            },
+          },
+        },
+        {
+          name = "false value",
+          input = {
+            { text = "No", value = false },
+          },
+          expected_item = { text = "No", value = false },
+          expected_value = false,
+        },
+        {
+          name = "missing value falls back to text",
+          input = {
+            { text = "display" },
+          },
+          expected_item = { text = "display", value = "display" },
+          expected_value = "display",
+        },
+        {
+          name = "format_item_text updates text only",
+          input = { "raw" },
+          opts = {
+            format_item_text = function(item)
+              return item.text .. "!"
+            end,
+          },
+          expected_item = { text = "raw!", value = "raw" },
+          expected_value = "raw",
+        },
+      }
+
+      for _, tc in ipairs(cases) do
+        run_named_case(tc.name, function()
+          local received_items
+
+          with_loaded_module(native_backend, {
+            pick = function(ctx)
+              received_items = ctx.items
+              ctx.on_select_item(ctx.items[1])
+            end,
+          }, function()
+            with_picker_buffer("native", function()
+              local selected
+              local called = false
+              local opts = vim.tbl_deep_extend("force", {}, tc.opts or {})
+              opts.on_select = function(value)
+                selected = value
+                called = true
+              end
+
+              local launched = picker.pick(tc.input, opts)
+
+              assert.is_true(launched)
+              assert.is_true(called)
+              assert.same({ tc.expected_item }, received_items)
+              assert.same(tc.expected_value, selected)
+            end)
+          end)
+        end)
+      end
     end)
 
-    ---@diagnostic disable-next-line: missing-fields
-    h.cm_setup({
-      ui = {
-        picker = "snacks",
-      },
-    })
-    h.setup_test_buffer({})
+    it("returns false for empty lists and contains on_select errors", function()
+      with_picker_buffer("native", function()
+        local select_called = false
+        local on_select_called = false
 
-    local ok = pcall(function()
-      picker.pick({ "item" })
+        with_native_select(function()
+          select_called = true
+        end, function()
+          local launched = picker.pick({}, {
+            on_select = function()
+              on_select_called = true
+            end,
+          })
+
+          assert.is_false(launched)
+          assert.is_false(select_called)
+          assert.is_false(on_select_called)
+        end)
+
+        with_native_select(function(items, _, on_choice)
+          on_choice(items[1], 1)
+        end, function()
+          local launched
+          local ok = pcall(function()
+            launched = picker.pick({ "item" }, {
+              on_select = function()
+                error("BOOM")
+              end,
+            })
+          end)
+
+          assert.is_true(ok)
+          assert.is_true(launched)
+        end)
+      end)
+    end)
+  end)
+
+  describe("validation", function()
+    it("rejects invalid picker options before backend dispatch", function()
+      local cases = {
+        {
+          name = "non-table picker_opts",
+          opts = {
+            ---@diagnostic disable-next-line: assign-type-mismatch
+            picker_opts = "native",
+          },
+        },
+        {
+          name = "non-callable picker_fn",
+          opts = {
+            ---@diagnostic disable-next-line: assign-type-mismatch
+            picker_fn = "not callable",
+          },
+        },
+        {
+          name = "non-string method",
+          opts = {
+            ---@diagnostic disable-next-line: assign-type-mismatch
+            method = {},
+          },
+        },
+        {
+          name = "unknown method",
+          opts = {
+            ---@diagnostic disable-next-line: assign-type-mismatch
+            method = "missing_method",
+          },
+        },
+      }
+
+      for _, tc in ipairs(cases) do
+        run_named_case(tc.name, function()
+          with_picker_buffer("native", function()
+            local select_called = false
+            local launched
+            local ok
+
+            with_native_select(function()
+              select_called = true
+            end, function()
+              ok, launched = pcall(function()
+                return picker.pick({ "item" }, tc.opts)
+              end)
+            end)
+
+            assert.is_true(ok)
+            assert.is_false(launched)
+            assert.is_false(select_called)
+          end)
+        end)
+      end
+    end)
+  end)
+
+  describe("todo picker integration", function()
+    it("jumps to a todo through the shared todo util", function()
+      local unchecked = h.get_unchecked_marker()
+
+      with_checkmate_buffer({
+        "- " .. unchecked .. " First",
+        "- " .. unchecked .. " Second",
+      }, function(bufnr)
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        ---@diagnostic disable-next-line: missing-fields
+        local ok = require("checkmate.todo.util").jump_to_todo({
+          bufnr = bufnr,
+          row = 1,
+        })
+
+        local cursor = vim.api.nvim_win_get_cursor(0)
+        assert.is_true(ok)
+        assert.equal(2, cursor[1])
+      end)
     end)
 
-    assert.is_true(ok)
-    assert.is_true(ran_native)
+    it("supports select_todo custom picker completion variants", function()
+      local unchecked = h.get_unchecked_marker()
+      local content = {
+        "- " .. unchecked .. " First",
+        "- " .. unchecked .. " Second",
+      }
 
-    finally(function()
-      ui_select_stub:revert()
-      package.loaded["snacks"] = nil
-      package.loaded["checkmate.picker.backends.snacks"] = nil
+      local cases = {
+        {
+          name = "raw todo selection jumps once",
+          custom_picker = function(ctx)
+            return function(todos, complete)
+              ctx.seen_todos = todos
+              complete(todos[2])
+              complete(todos[1])
+            end
+          end,
+          expected_cursor = 2,
+          assert = function(ctx)
+            assert.is_table(ctx.seen_todos)
+            assert.equal(2, #ctx.seen_todos)
+          end,
+        },
+        {
+          -- the was the signature in v0.12, i.e., no arg for complete fn
+          name = "custom_picker(todos) compatibility",
+          custom_picker = function(ctx)
+            return function(todos)
+              ctx.seen_count = #todos
+            end
+          end,
+          expected_cursor = 1,
+          assert = function(ctx)
+            assert.equal(2, ctx.seen_count)
+          end,
+        },
+        {
+          name = "nil completion cancels and wins",
+          custom_picker = function()
+            return function(todos, complete)
+              complete(nil)
+              complete(todos[2])
+            end
+          end,
+          expected_cursor = 1,
+        },
+      }
+
+      for _, tc in ipairs(cases) do
+        run_named_case(tc.name, function()
+          with_checkmate_buffer(content, function(_, cm)
+            vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+            local ctx = {}
+            local ok = cm.select_todo({
+              custom_picker = tc.custom_picker(ctx),
+            })
+
+            vim.wait(100, function()
+              return vim.api.nvim_win_get_cursor(0)[1] == tc.expected_cursor
+            end)
+
+            local cursor = vim.api.nvim_win_get_cursor(0)
+            assert.is_true(ok)
+            assert.equal(tc.expected_cursor, cursor[1])
+
+            if tc.assert then
+              tc.assert(ctx)
+            end
+          end)
+        end)
+      end
+    end)
+
+    it("rejects non-callable select_todo custom_picker values", function()
+      local unchecked = h.get_unchecked_marker()
+
+      with_checkmate_buffer({ "- " .. unchecked .. " First" }, function(_, cm)
+        local ok = cm.select_todo({
+          ---@diagnostic disable-next-line: assign-type-mismatch
+          custom_picker = "nope",
+        })
+
+        assert.is_false(ok)
+      end)
+    end)
+  end)
+
+  describe("metadata picker integration", function()
+    it("handles select_metadata_value custom picker errors and cancellation", function()
+      local cases = {
+        {
+          name = "custom picker error returns false",
+          expected_ok = false,
+          custom_picker = function()
+            error("BOOM")
+          end,
+        },
+        {
+          name = "nil completion cancels and wins",
+          expected_ok = true,
+          custom_picker = function(_, complete)
+            complete(nil)
+            complete("high")
+          end,
+        },
+      }
+
+      for _, tc in ipairs(cases) do
+        run_named_case(tc.name, function()
+          with_metadata_value_at_cursor(function(bufnr, cm, unchecked)
+            local ok = cm.select_metadata_value({
+              custom_picker = tc.custom_picker,
+            })
+
+            vim.wait(50)
+
+            local line = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)[1]
+            assert.equal(tc.expected_ok, ok)
+            assert.equal("- " .. unchecked .. " Task @priority(low)", line)
+          end)
+        end)
+      end
     end)
   end)
 end)


### PR DESCRIPTION
- Clarifies picker completion contracts with item/value completion helpers
- Moves select_todo picker behavior into todo/picker.lua and shared jump behavior into todo/util.lua.
- Adds complete(todo/item/nil) support to select_todo custom pickers.
- Ensures picker completions are one-shot, cancellation-aware, callback-safe, and scheduled by default
- Renames internal item follow-up hook to after_item_select

## Behavior notes
PR should be **non-breaking** for public APIs.

- select_todo custom_picker(todos) remains compatible.
- select_todo custom_picker(todos, complete) can now call complete(todo), complete(item), or complete(nil).
- Invalid select_todo custom_picker values now return false with a warning.
- select_metadata_value custom picker errors now return false.
- Advanced picker_fn users should not assume on_select runs synchronously before picker.pick returns.
