### PR TITLE
fix(log)!: add safety to log functions, adjust config log levels

### DIFF
--- a/lua/checkmate/config/init.lua
+++ b/lua/checkmate/config/init.lua
@@ -167,7 +167,7 @@ M.options = {}
 
 ---@class checkmate.LogSettings
 --- Any messages above this level will be logged
----@field level ("trace" | "debug" | "info" | "warn" | "error" | "fatal" | vim.log.levels.DEBUG | vim.log.levels.ERROR | vim.log.levels.INFO | vim.log.levels.TRACE | vim.log.levels.WARN)?
+---@field level ("trace" | "debug" | "info" | "warn" | "error" | "off" | vim.log.levels.DEBUG | vim.log.levels.ERROR | vim.log.levels.INFO | vim.log.levels.TRACE | vim.log.levels.WARN | vim.log.levels.OFF)?
 ---
 --- Should print log output to a file
 --- Default: true

--- a/lua/checkmate/log.lua
+++ b/lua/checkmate/log.lua
@@ -1,4 +1,4 @@
----@alias basic_log fun(args: any)
+---@alias basic_log fun(...: any)
 ---@alias fmt_log fun(format_string: string, ...)
 ---@alias lazy_log fun(lazy_fn: fun())
 
@@ -20,14 +20,7 @@
 ---@field lazy_error lazy_log
 local M = {}
 
-M.levels = {
-  TRACE = 0,
-  DEBUG = 1,
-  INFO = 2,
-  WARN = 3,
-  ERROR = 4,
-  OFF = 5,
-}
+M.levels = vim.log.levels
 
 local level_map = {
   trace = M.levels.TRACE,
@@ -39,65 +32,66 @@ local level_map = {
 }
 
 local DEFAULT_NAME = "checkmate.log"
+local DEFAULT_MAX_FILE_SIZE_KB = 5 * 1024
 local log_file = nil
 local log_file_path = nil
 
+local function safe_tostring(value)
+  if type(value) == "string" then
+    return value
+  end
+
+  local ok, result = pcall(tostring, value)
+  return ok and result or ("<" .. type(value) .. ">")
+end
+
 local function ensure_default_log_dir()
   local log_dir = vim.fs.joinpath(vim.fn.stdpath("log"))
-  vim.fn.mkdir(log_dir, "p") -- 'p' ensures parent dirs are created if needed
+  pcall(vim.fn.mkdir, log_dir, "p")
   return log_dir
 end
 
 local function get_log_file_path(customPath)
   local function get_default_path()
-    local log_dir = ensure_default_log_dir()
-    return vim.fs.joinpath(log_dir, DEFAULT_NAME)
+    return vim.fs.joinpath(ensure_default_log_dir(), DEFAULT_NAME)
   end
 
   if not customPath or type(customPath) ~= "string" or customPath == "" then
     return get_default_path()
   end
 
-  -- expand ~ and env vars (like $HOME)
-  local expanded = vim.fn.expand(customPath)
+  local looks_like_dir = customPath:match("[/\\]$")
+  local expanded = vim.fs.normalize(customPath)
 
   if expanded == "" then
     vim.notify("Checkmate: Invalid log path: " .. customPath, vim.log.levels.WARN)
-    -- fallback to default
-    local log_dir = ensure_default_log_dir()
-    return vim.fs.joinpath(log_dir, DEFAULT_NAME)
+    return get_default_path()
   end
 
   local absolute = vim.fn.fnamemodify(expanded, ":p")
-
   local stat = vim.uv.fs_stat(absolute)
+
   if stat and stat.type == "directory" then
-    -- existing directory
     absolute = vim.fs.joinpath(absolute, DEFAULT_NAME)
   elseif not stat then
-    -- path doesn't exist yet
-    if absolute:match("[/\\]$") or not absolute:match("%.%w+$") then
-      -- ends with separator OR has no extension = directory
-      vim.fn.mkdir(absolute, "p")
+    if looks_like_dir or not absolute:match("%.%w+$") then
+      pcall(vim.fn.mkdir, absolute, "p")
       absolute = vim.fs.joinpath(absolute, DEFAULT_NAME)
     else
-      -- has extension = file
       local parent = vim.fs.dirname(absolute)
       if parent and parent ~= "" then
-        vim.fn.mkdir(parent, "p")
+        pcall(vim.fn.mkdir, parent, "p")
       end
     end
   else
-    -- file path (existing or not): ensure parent exists
     local parent = vim.fs.dirname(absolute)
     if parent and parent ~= "" then
-      vim.fn.mkdir(parent, "p")
+      pcall(vim.fn.mkdir, parent, "p")
     end
   end
 
-  -- verify parent directory is writable
   local parent_dir = vim.fs.dirname(absolute)
-  if vim.uv.fs_access(parent_dir, "W") then
+  if parent_dir and not vim.uv.fs_access(parent_dir, "W") then
     vim.notify("Checkmate: Log directory not writable: " .. parent_dir, vim.log.levels.WARN)
     return get_default_path()
   end
@@ -125,16 +119,29 @@ local function make_string(...)
     local x = select(i, ...)
 
     if type(x) == "number" then
-      x = tostring(round(x, 0.01))
+      x = safe_tostring(round(x, 0.01))
     elseif type(x) == "table" then
-      x = vim.inspect(x)
+      local ok, inspected = pcall(vim.inspect, x)
+      x = ok and inspected or safe_tostring(x)
     else
-      x = tostring(x)
+      x = safe_tostring(x)
     end
 
     t[#t + 1] = x
   end
   return table.concat(t, " ")
+end
+
+local function format_message(format_str, ...)
+  local fmt = safe_tostring(format_str)
+  local ok, result = pcall(string.format, fmt, ...)
+
+  if ok then
+    return result
+  end
+
+  local suffix = make_string(...)
+  return suffix ~= "" and (fmt .. " " .. suffix) or fmt
 end
 
 local function format_log(level_name, msg, source_info)
@@ -147,7 +154,7 @@ local function format_log(level_name, msg, source_info)
     table.insert(parts, string.format("[%s:%d]", source_info.path, source_info.line))
   end
 
-  table.insert(parts, msg)
+  table.insert(parts, safe_tostring(msg))
   return table.concat(parts, " ")
 end
 
@@ -163,17 +170,69 @@ local function get_source_info(level)
   return nil
 end
 
+local function get_log_options()
+  local ok, config = pcall(require, "checkmate.config")
+  if not ok or type(config) ~= "table" or type(config.options) ~= "table" or type(config.options.log) ~= "table" then
+    return {}
+  end
+  return config.options.log
+end
+
+local function normalize_level(level)
+  if type(level) == "string" then
+    return level_map[level:lower()] or M.levels.INFO
+  end
+  if type(level) == "number" then
+    return level
+  end
+  return M.levels.INFO
+end
+
+local function get_max_file_size_bytes(max_file_size)
+  local kb = tonumber(max_file_size) or DEFAULT_MAX_FILE_SIZE_KB
+  if kb <= 0 then
+    kb = DEFAULT_MAX_FILE_SIZE_KB
+  end
+  return kb * 1024
+end
+
+local function close_log_file()
+  if log_file then
+    pcall(function()
+      log_file:close()
+    end)
+    log_file = nil
+  end
+end
+
+local function write_log_line(line)
+  if not log_file then
+    return
+  end
+
+  local ok = pcall(function()
+    log_file:write(line .. "\n")
+    log_file:flush()
+  end)
+
+  if not ok then
+    close_log_file()
+  end
+end
+
 local function log_at_level(level, level_name, message_maker, ...)
-  local config = require("checkmate.config")
-  local options = config.options.log
-  local current_level = level_map[options.level] or M.levels.INFO
+  local options = get_log_options()
+  local current_level = normalize_level(options.level)
 
   -- skip if current level is higher than this message's level
   if level < current_level then
     return
   end
 
-  local msg = message_maker(...)
+  local ok, msg = pcall(message_maker, ...)
+  if not ok then
+    msg = "[log] failed to create log message: " .. safe_tostring(msg)
+  end
 
   -- get source info if configured
   local source_info = nil
@@ -184,8 +243,7 @@ local function log_at_level(level, level_name, message_maker, ...)
   local formatted = format_log(level_name, msg, source_info)
 
   if options.use_file and log_file then
-    log_file:write(formatted .. "\n")
-    log_file:flush()
+    write_log_line(formatted)
   end
 end
 
@@ -204,51 +262,39 @@ local function create_logger_methods()
 
     -- Formatted logging: M.fmt_debug("Hello %s", "world")
     M["fmt_" .. name] = function(fmt, ...)
-      return log_at_level(level, level_name, function(format_str, ...)
-        -- protect against format string errors
-        local args = { ... }
-        local ok, result = pcall(function()
-          local inspected = {}
-          for _, v in ipairs(args) do
-            table.insert(inspected, type(v) == "table" and vim.inspect(v) or tostring(v))
-          end
-          return string.format(format_str, unpack(inspected))
-        end)
-
-        if not ok then
-          -- basic concatenation if format fails
-          return format_str .. " " .. make_string(...)
-        end
-        return result
-      end, fmt, ...)
+      return log_at_level(level, level_name, format_message, fmt, ...)
     end
 
     -- Lazy logging: M.lazy_debug(function() return expensive_calculation() end)
     M["lazy_" .. name] = function(fn)
       return log_at_level(level, level_name, function(f)
-        return tostring(f())
+        if not vim.is_callable(f) then
+          return "[log] lazy logger expected function, got " .. type(f)
+        end
+
+        local ok, result = pcall(f)
+        if not ok then
+          return "[log] lazy logger failed: " .. safe_tostring(result)
+        end
+        return make_string(result)
       end, fn)
     end
   end
 end
 
 function M.setup()
-  local config = require("checkmate.config")
-  local options = config.options.log
+  local options = get_log_options()
 
   if options.use_file then
+    close_log_file()
+
     log_file_path = get_log_file_path(options.file_path)
 
     local append_mode = true
     local file_size = get_file_size(log_file_path)
-    local default_max_file_size = 5 * 1024 -- 5120 kb
-    local max_file_size = (config.options.log.max_file_size or default_max_file_size * 1024) -- convert to bytes
+    local max_file_size = get_max_file_size_bytes(options.max_file_size)
     if file_size > max_file_size then
       append_mode = false
-      if log_file then
-        log_file:close()
-        log_file = nil
-      end
     end
 
     local ok, file = pcall(io.open, log_file_path, append_mode and "a" or "w")
@@ -259,21 +305,15 @@ function M.setup()
         path = log_file_path,
         max_file_size = tostring(max_file_size / (1024 ^ 2)) .. " mb",
       }
-      local msg = "[log] Checkmate logger initialized:\n" .. vim.inspect(info)
-      local formatted = format_log("INFO", msg, nil)
-      log_file:write(formatted .. "\n")
-      log_file:flush()
+      write_log_line(format_log("INFO", "[log] Checkmate logger initialized:\n" .. vim.inspect(info), nil))
     else
-      vim.notify("Checkmate: Failed to open log file: " .. log_file_path, vim.log.levels.ERROR)
+      vim.notify("Checkmate: Failed to open log file: " .. safe_tostring(log_file_path), vim.log.levels.ERROR)
     end
   end
 end
 
 function M.shutdown()
-  if log_file then
-    log_file:close()
-    log_file = nil
-  end
+  close_log_file()
 end
 
 function M.get_log_path()
@@ -282,31 +322,34 @@ end
 
 ---@param opts? {scratch?: "floating" | "split"}
 function M.open(opts)
-  opts = opts or {}
+  opts = type(opts) == "table" and opts or {}
 
   if opts.scratch then
     local scratch =
       require("checkmate.ui.scratch").open({ floating = opts.scratch == "floating", ft = "checkmate_log" })
 
     if log_file_path and vim.fn.filereadable(log_file_path) == 1 then
-      local lines = vim.fn.readfile(log_file_path)
-      scratch:set(lines)
+      local ok, lines = pcall(vim.fn.readfile, log_file_path)
+      scratch:set(ok and lines or { "Log file not found or not readable: " .. log_file_path })
     else
       scratch:set({ "Log file not found or not readable: " .. (log_file_path or "no path set") })
     end
   else
-    vim.cmd(string.format("tabnew %s", log_file_path))
+    if not log_file_path then
+      vim.notify("Checkmate: Log file path is not set", vim.log.levels.WARN)
+      return
+    end
+    ---@diagnostic disable-next-line: param-type-mismatch
+    pcall(vim.cmd, "tabnew " .. vim.fn.fnameescape(log_file_path))
   end
 end
 
 function M.clear()
-  local config = require("checkmate.config")
-  local options = config.options.log
+  local options = get_log_options()
 
   if options.use_file then
-    if log_file then
-      log_file:close()
-    end
+    close_log_file()
+    log_file_path = log_file_path or get_log_file_path(options.file_path)
 
     local ok, file = pcall(io.open, log_file_path, "w")
     if ok and file then
@@ -318,7 +361,7 @@ end
 
 function M.log_error(err, context)
   if err then
-    M.error(string.format("%s: %s", context or "Error", tostring(err)))
+    M.fmt_error("%s: %s", context or "Error", err)
     return true
   end
   return false

--- a/tests/checkmate/log_spec.lua
+++ b/tests/checkmate/log_spec.lua
@@ -1,7 +1,8 @@
 describe("Log", function()
-  local get_log_file_path = require("checkmate.log")._get_log_file_path
-
-  local default_path = vim.fs.joinpath(vim.fn.stdpath("log"), "checkmate.log")
+  local log
+  local get_log_file_path
+  local config
+  local default_path
 
   ---@type luassert.spy
   local fs_access_stub
@@ -9,17 +10,43 @@ describe("Log", function()
   local fs_stat_stub
   ---@type luassert.spy
   local mkdir_stub
+  ---@type luassert.spy
+  local notify_stub
+  ---@type luassert.spy
+  local io_open_stub
 
   before_each(function()
-    fs_access_stub = stub(vim.uv, "fs_access", nil)
+    _G.reset_state()
+
+    log = require("checkmate.log")
+    get_log_file_path = log._get_log_file_path
+    config = require("checkmate.config")
+    config.options = vim.deepcopy(config.get_defaults())
+    config.options.log = { level = "trace", use_file = false }
+    default_path = vim.fs.joinpath(vim.fn.stdpath("log"), "checkmate.log")
+
+    fs_access_stub = stub(vim.uv, "fs_access", function()
+      return true
+    end)
     fs_stat_stub = stub(vim.uv, "fs_stat", nil)
     mkdir_stub = stub(vim.fn, "mkdir")
+    notify_stub = stub(vim, "notify")
   end)
 
   after_each(function()
+    pcall(function()
+      log.shutdown()
+    end)
+
+    if io_open_stub then
+      io_open_stub:revert()
+      ---@diagnostic disable-next-line: cast-local-type
+      io_open_stub = nil
+    end
     fs_access_stub:revert()
     fs_stat_stub:revert()
     mkdir_stub:revert()
+    notify_stub:revert()
   end)
 
   describe("get_log_file_path()", function()
@@ -36,19 +63,91 @@ describe("Log", function()
     it("handles directory with trailing slash", function()
       local path = get_log_file_path("/tmp/logs/")
       assert.equal("/tmp/logs/checkmate.log", path)
-      fs_access_stub:called_with({ "/tmp/logs" })
+      assert.stub(fs_access_stub).was.called_with("/tmp/logs", "W")
     end)
 
     it("preserves .log extension", function()
       local path = get_log_file_path("/tmp/custom.log")
       assert.equal("/tmp/custom.log", path)
-      fs_access_stub:called_with({ "/tmp" })
+      assert.stub(fs_access_stub).was.called_with("/tmp", "W")
     end)
 
     it("treats paths without extension as directories", function()
       local path = get_log_file_path("/tmp/logdir")
       assert.equal("/tmp/logdir/checkmate.log", path)
-      fs_access_stub:called_with({ "/tmp/logdir" })
+      assert.stub(fs_access_stub).was.called_with("/tmp/logdir", "W")
+    end)
+
+    it("falls back to the default path when the target directory is not writable", function()
+      fs_access_stub:revert()
+      fs_access_stub = stub(vim.uv, "fs_access", function()
+        return false
+      end)
+
+      local path = get_log_file_path("/tmp/custom.log")
+      assert.equal(default_path, path)
+    end)
+  end)
+
+  describe("logger methods", function()
+    it("does not error when file writes fail", function()
+      config.options.log = {
+        level = "trace",
+        use_file = true,
+        file_path = "/tmp/checkmate.log",
+      }
+
+      io_open_stub = stub(io, "open", function()
+        return {
+          write = function()
+            error("write failed")
+          end,
+          flush = function()
+            error("flush failed")
+          end,
+          close = function() end,
+        }
+      end)
+
+      assert.has_no_error(function()
+        log.setup()
+        log.info("after failed setup write")
+        log.clear()
+      end)
+    end)
+
+    it("treats max_file_size as kilobytes", function()
+      fs_stat_stub:revert()
+      fs_stat_stub = stub(vim.uv, "fs_stat", function()
+        return { size = 2 * 1024 }
+      end)
+
+      local opened_mode
+      io_open_stub = stub(io, "open", function(_, mode)
+        opened_mode = mode
+        return {
+          write = function()
+            return true
+          end,
+          flush = function()
+            return true
+          end,
+          close = function()
+            return true
+          end,
+        }
+      end)
+
+      config.options.log = {
+        level = "trace",
+        use_file = true,
+        file_path = "/tmp/checkmate.log",
+        max_file_size = 3,
+      }
+
+      log.setup()
+
+      assert.equal("a", opened_mode)
     end)
   end)
 end)


### PR DESCRIPTION
Breaking because log levels in config's |checkmate.LogSettings| are slightly adjusted to align with vim.log.levels